### PR TITLE
multi-backend fix for Prometheus error

### DIFF
--- a/lib/ddnssd/backend.rb
+++ b/lib/ddnssd/backend.rb
@@ -14,7 +14,11 @@ module DDNSSD
       @config = config
       @logger = @config.logger
 
-      @request_stats = Frankenstein::Request.new(:ddnssd_backend, description: "DNS backend", registry: @config.metrics_registry)
+      @request_stats = Frankenstein::Request.new(
+        "ddnssd_backend_#{name}",
+        description: "DNS backend #{name}",
+        registry: @config.metrics_registry
+      )
 
       @shared_records = {}
     end


### PR DESCRIPTION
Using two backends causes ddns-sd to fail to start because of: Prometheus::Client::Registry::AlreadyRegisteredError: ddnssd_backend_requests_total has already been registered

Add the backend name to the name.