### PR TITLE
Change more places that use `DDNSSD_BASE_DOMAIN`

### DIFF
--- a/lib/ddnssd/backend.rb
+++ b/lib/ddnssd/backend.rb
@@ -101,6 +101,10 @@ module DDNSSD
       end
     end
 
+    def base_domain
+      backend_config["BASE_DOMAIN"] || @config.base_domain
+    end
+
     private
 
     def progname
@@ -109,10 +113,6 @@ module DDNSSD
 
     def backend_config
       @config.backend_configs[name]
-    end
-
-    def base_domain
-      backend_config["BASE_DOMAIN"] || @config.base_domain
     end
   end
 end

--- a/lib/ddnssd/container.rb
+++ b/lib/ddnssd/container.rb
@@ -36,8 +36,8 @@ module DDNSSD
       @id[0..11]
     end
 
-    def dns_records
-      @service_instances.map { |si| si.dns_records }.flatten(1)
+    def dns_records(base_domain = nil)
+      @service_instances.map { |si| si.dns_records(base_domain || @config.base_domain) }.flatten(1)
     end
 
     def port_exposed?(spec)

--- a/lib/ddnssd/service_instance.rb
+++ b/lib/ddnssd/service_instance.rb
@@ -7,13 +7,15 @@ module DDNSSD
   class ServiceInstance
     class ServiceInstanceValidationError < DDNSSD::Error; end
 
+    attr_reader :name, :labels, :container, :config, :container_desc
+
     def initialize(name, labels, container, config)
       @name, @labels, @container, @config = name, labels, container, config
 
       @logger = @config.logger
     end
 
-    def dns_records
+    def dns_records(base_domain = nil)
       unless @container.addressable?
         @logger.debug(progname) { "Container #{@container.name} does not have IP addresses; not creating DNS records for service #{@name}" }
         return []
@@ -27,98 +29,26 @@ module DDNSSD
           end
         end
 
+        d = DNSRecords.new(self, protos, base_domain || @config.base_domain)
+
         # This ordering is quite particular; it makes sure that records
         # which reference other records are created after the referenced
         # records.  That's not *essential*, but it is polite.
-        a_records + aaaa_records + srv_records + txt_records + ptr_records + cname_records
+        d.a_records + d.aaaa_records + d.srv_records + d.txt_records + d.ptr_records + d.cname_records
       rescue ServiceInstanceValidationError => ex
         @logger.error(progname) { "#{ex.message} Service not registered." }
         return []
       end
     end
 
-    private
-
-    def progname
-      @logger_progname ||= "DDNSSD::ServiceInstance(#{@name})"
-    end
-
     def container_desc
       "#{@container.short_id} (#{@container.name.inspect})"
     end
 
-    def host_fqdn
-      "#{@config.hostname}.#{@config.base_domain}"
-    end
+    private
 
-    def container_fqdn
-      "#{@container.short_id}.#{host_fqdn}"
-    end
-
-    def address_fqdn
-      "#{instance_v4_address.gsub('.', '-')}.#{host_fqdn}"
-    end
-
-    def instance_address_fqdn
-      if @container.host_network
-        host_fqdn
-      elsif @container.host_port_for("#{@labels["port"]}/#{protos.first}")
-        if @container.host_address_for("#{@labels["port"]}/#{protos.first}")
-          address_fqdn
-        else
-          host_fqdn
-        end
-      else
-        container_fqdn
-      end
-    end
-
-    def service_fqdn(proto)
-      "_#{@name}._#{proto}.#{@config.base_domain}"
-    end
-
-    def instance_v4_address
-      if @container.host_port_for("#{@labels["port"]}/#{protos.first}")
-        if pub_addr = @container.host_address_for("#{@labels["port"]}/#{protos.first}")
-          pub_addr
-        else
-          if @config.host_ip_address.nil?
-            raise ServiceInstanceValidationError,
-              "Published port on default IP address detected on container #{container_desc}, but no host IP address configured."
-          end
-
-          nil
-        end
-      else
-        @container.ipv4_address
-      end
-    end
-
-    def srv_instance_fqdn(proto)
-      name = @labels["instance"] || @container.name
-      name.force_encoding("UTF-8")
-
-      if name.bytesize == 0
-        raise ServiceInstanceValidationError,
-          "Instance name on container #{container_desc} is empty."
-      end
-
-      if name.bytesize > 63
-        raise ServiceInstanceValidationError,
-          "Instance name #{name.inspect} on container #{container_desc} is too long (must be <= 63 octets)."
-      end
-
-      unless name.valid_encoding?
-        raise ServiceInstanceValidationError,
-          "Instance name #{name.inspect} on container #{container_desc} is not valid UTF-8."
-      end
-
-      unless name =~ /\A[^\u0000-\u001f\u007f]+\z/
-        raise ServiceInstanceValidationError,
-          "Instance name #{name.inspect} on container #{container_desc} is not valid Net-Unicode (contains ASCII control characters)."
-      end
-
-      "#{name}.#{service_fqdn(proto)}"
+    def progname
+      @logger_progname ||= "DDNSSD::ServiceInstance(#{@name})"
     end
 
     def protos
@@ -137,124 +67,212 @@ module DDNSSD
       end
     end
 
-    def a_records
-      if !@container.host_network && instance_v4_address
-        [DDNSSD::DNSRecord.new(instance_address_fqdn, @config.record_ttl, :A, instance_v4_address)]
-      else
-        []
+    # This class calculates the DNS records for the given service instance
+    # for the given protocols and base domain.
+    class DNSRecords
+      def initialize(service_instance, protos, base_domain)
+        @service_instance, @protos, @base_domain = service_instance, protos, base_domain
+
+        @name = service_instance.name
+        @labels = service_instance.labels
+        @container = service_instance.container
+        @config = service_instance.config
       end
-    end
 
-    def aaaa_records
-      if  @container.host_network ||
-          @container.host_port_for("#{@labels["port"]}/#{protos.first}") ||
-          @container.ipv6_address.nil? ||
-          @container.ipv6_address.empty?
-        []
-      else
-
-        [DDNSSD::DNSRecord.new(instance_address_fqdn, @config.record_ttl, :AAAA, @container.ipv6_address)]
+      def host_fqdn
+        "#{@config.hostname}.#{@base_domain}"
       end
-    end
 
-    def parse_ushort_label(k)
-      if @labels[k]
-        unless @labels[k] =~ /\A\d+\z/
+      def container_fqdn
+        "#{@container.short_id}.#{host_fqdn}"
+      end
+
+      def address_fqdn
+        "#{instance_v4_address.gsub('.', '-')}.#{host_fqdn}"
+      end
+
+      def instance_address_fqdn
+        if @container.host_network
+          host_fqdn
+        elsif @container.host_port_for("#{@labels["port"]}/#{@protos.first}")
+          if @container.host_address_for("#{@labels["port"]}/#{@protos.first}")
+            address_fqdn
+          else
+            host_fqdn
+          end
+        else
+          container_fqdn
+        end
+      end
+
+      def service_fqdn(proto)
+        "_#{@name}._#{proto}.#{@base_domain}"
+      end
+
+      def instance_v4_address
+        if @container.host_port_for("#{@labels["port"]}/#{@protos.first}")
+          if pub_addr = @container.host_address_for("#{@labels["port"]}/#{@protos.first}")
+            pub_addr
+          else
+            if @config.host_ip_address.nil?
+              raise ServiceInstanceValidationError,
+                "Published port on default IP address detected on container #{@service_instance.container_desc}, but no host IP address configured."
+            end
+
+            nil
+          end
+        else
+          @container.ipv4_address
+        end
+      end
+
+      def srv_instance_fqdn(proto)
+        name = @labels["instance"] || @container.name
+        name.force_encoding("UTF-8")
+
+        if name.bytesize == 0
           raise ServiceInstanceValidationError,
-            "Value #{@labels[k].inspect} for label org.discourse.service._#{@name}.#{k} on #{container_desc} is not a number."
+            "Instance name on container #{@service_instance.container_desc} is empty."
         end
 
-        unless (0..65535).include?(@labels[k].to_i)
+        if name.bytesize > 63
           raise ServiceInstanceValidationError,
-            "Value #{@labels[k].inspect} for label org.discourse.service._#{@name}.#{k} on #{container_desc} is invalid (must be between 0-65535 inclusive)."
+            "Instance name #{name.inspect} on container #{@service_instance.container_desc} is too long (must be <= 63 octets)."
         end
 
-        @labels[k].to_i
-      else
-        0
+        unless name.valid_encoding?
+          raise ServiceInstanceValidationError,
+            "Instance name #{name.inspect} on container #{@service_instance.container_desc} is not valid UTF-8."
+        end
+
+        unless name =~ /\A[^\u0000-\u001f\u007f]+\z/
+          raise ServiceInstanceValidationError,
+            "Instance name #{name.inspect} on container #{@service_instance.container_desc} is not valid Net-Unicode (contains ASCII control characters)."
+        end
+
+        "#{name}.#{service_fqdn(proto)}"
       end
-    end
 
-    def srv_records
-      priority = parse_ushort_label("priority")
-      weight   = parse_ushort_label("weight")
+      def a_records
+        if !@container.host_network && instance_v4_address
+          [DDNSSD::DNSRecord.new(instance_address_fqdn, @config.record_ttl, :A, instance_v4_address)]
+        else
+          []
+        end
+      end
 
-      protos.map do |proto|
-        port = @container.host_port_for("#{@labels["port"]}/#{proto}") || @labels["port"]
+      def aaaa_records
+        if  @container.host_network ||
+            @container.host_port_for("#{@labels["port"]}/#{@protos.first}") ||
+            @container.ipv6_address.nil? ||
+            @container.ipv6_address.empty?
+          []
+        else
 
-        DDNSSD::DNSRecord.new(srv_instance_fqdn(proto),
+          [DDNSSD::DNSRecord.new(instance_address_fqdn, @config.record_ttl, :AAAA, @container.ipv6_address)]
+        end
+      end
+
+      def parse_ushort_label(k)
+        if @labels[k]
+          unless @labels[k] =~ /\A\d+\z/
+            raise ServiceInstanceValidationError,
+              "Value #{@labels[k].inspect} for label org.discourse.service._#{@name}.#{k} on #{@service_instance.container_desc} is not a number."
+          end
+
+          unless (0..65535).include?(@labels[k].to_i)
+            raise ServiceInstanceValidationError,
+              "Value #{@labels[k].inspect} for label org.discourse.service._#{@name}.#{k} on #{@service_instance.container_desc} is invalid (must be between 0-65535 inclusive)."
+          end
+
+          @labels[k].to_i
+        else
+          0
+        end
+      end
+
+      def srv_records
+        priority = parse_ushort_label("priority")
+        weight   = parse_ushort_label("weight")
+
+        @protos.map do |proto|
+          port = @container.host_port_for("#{@labels["port"]}/#{proto}") || @labels["port"]
+
+          DDNSSD::DNSRecord.new(srv_instance_fqdn(proto),
             @config.record_ttl,
             :SRV,
             priority,
             weight,
             port.to_i,
             instance_address_fqdn
-        )
-      end
-    end
-
-    def ptr_records
-      protos.map do |proto|
-        DDNSSD::DNSRecord.new(service_fqdn(proto), @config.record_ttl, :PTR, srv_instance_fqdn(proto))
-      end
-    end
-
-    def validate_tag_key(k)
-      if k == ""
-        raise ServiceInstanceValidationError,
-          "Tag label set on #{container_desc} has an empty tag key."
-      end
-
-      if k.include?("=")
-        raise ServiceInstanceValidationError,
-          "Tag key #{k.inspect} on #{container_desc} contains an equals sign, which is forbidden."
-      end
-
-      unless k =~ /\A[\x20-\x7e]+\z/
-        raise ServiceInstanceValidationError,
-          "Tag label #{k.inspect} on #{container_desc} contains a forbidden character (only printable ASCII allowed)."
-      end
-    end
-
-    def parse_tag_labels
-      value_tags = @labels.select { |k, v| k =~ /\Atag\./ }.map do |k, v|
-        k = k.sub(/\Atag\./, '')
-
-        validate_tag_key(k)
-
-        "#{k}=#{v}"
-      end
-
-      boolean_tags = @labels["tags"].to_s.split("\n").each { |t| validate_tag_key(t) }
-
-      tags = value_tags + boolean_tags
-
-      tags.each do |t|
-        if t.bytesize > 255
-          raise ServiceInstanceValidationError,
-            "Tag #{t.inspect} on #{container_desc} is too long (must be <= 255 octets)."
+          )
         end
       end
 
-      tags.sort_by! { |v| v =~ /\Atxtvers=/ ? 0 : 1 }
+      def ptr_records
+        @protos.map do |proto|
+          DDNSSD::DNSRecord.new(service_fqdn(proto), @config.record_ttl, :PTR, srv_instance_fqdn(proto))
+        end
+      end
 
-      if tags.empty?
-        [""]
-      else
-        tags
+      def txt_records
+        @protos.map do |proto|
+          DDNSSD::DNSRecord.new(srv_instance_fqdn(proto), @config.record_ttl, :TXT, *parse_tag_labels)
+        end
+      end
+
+      def cname_records
+        @labels["aliases"].to_s.split(',').map do |relrrname|
+          DDNSSD::DNSRecord.new("#{relrrname}.#{@base_domain}", @config.record_ttl, :CNAME, instance_address_fqdn)
+        end
+      end
+
+      def parse_tag_labels
+        value_tags = @labels.select { |k, v| k =~ /\Atag\./ }.map do |k, v|
+          k = k.sub(/\Atag\./, '')
+
+          validate_tag_key(k)
+
+          "#{k}=#{v}"
+        end
+
+        boolean_tags = @labels["tags"].to_s.split("\n").each { |t| validate_tag_key(t) }
+
+        tags = value_tags + boolean_tags
+
+        tags.each do |t|
+          if t.bytesize > 255
+            raise ServiceInstanceValidationError,
+              "Tag #{t.inspect} on #{@service_instance.container_desc} is too long (must be <= 255 octets)."
+          end
+        end
+
+        tags.sort_by! { |v| v =~ /\Atxtvers=/ ? 0 : 1 }
+
+        if tags.empty?
+          [""]
+        else
+          tags
+        end
+      end
+
+      def validate_tag_key(k)
+        if k == ""
+          raise ServiceInstanceValidationError,
+            "Tag label set on #{@service_instance.container_desc} has an empty tag key."
+        end
+
+        if k.include?("=")
+          raise ServiceInstanceValidationError,
+            "Tag key #{k.inspect} on #{@service_instance.container_desc} contains an equals sign, which is forbidden."
+        end
+
+        unless k =~ /\A[\x20-\x7e]+\z/
+          raise ServiceInstanceValidationError,
+            "Tag label #{k.inspect} on #{@service_instance.container_desc} contains a forbidden character (only printable ASCII allowed)."
+        end
       end
     end
 
-    def txt_records
-      protos.map do |proto|
-        DDNSSD::DNSRecord.new(srv_instance_fqdn(proto), @config.record_ttl, :TXT, *parse_tag_labels)
-      end
-    end
-
-    def cname_records
-      @labels["aliases"].to_s.split(',').map do |relrrname|
-        DDNSSD::DNSRecord.new("#{relrrname}.#{@config.base_domain}", @config.record_ttl, :CNAME, instance_address_fqdn)
-      end
-    end
   end
 end

--- a/lib/ddnssd/system.rb
+++ b/lib/ddnssd/system.rb
@@ -120,8 +120,8 @@ module DDNSSD
 
       containers = @containers.values
 
-      our_live_records = backend.dns_records.select { |rr| our_record?(rr) }
-      our_desired_records = containers.map { |c| c.dns_records }.flatten(1)
+      our_live_records = backend.dns_records.select { |rr| our_record?(rr, backend.base_domain) }
+      our_desired_records = containers.map { |c| c.dns_records(backend.base_domain) }.flatten(1)
 
       @logger.info(progname) { "Found #{our_live_records.length} relevant DNS records." }
       @logger.debug(progname) { (["Relevant DNS records:"] + our_live_records.map { |rr| "#{rr.name} #{rr.ttl} #{rr.type} #{rr.value}" }).join("\n  ") } unless our_live_records.empty?
@@ -137,8 +137,8 @@ module DDNSSD
       (our_desired_records - our_live_records).uniq.each { |rr| backend.publish_record(rr) }
     end
 
-    def our_record?(rr)
-      suffix = /#{Regexp.escape(@config.hostname)}\.#{Regexp.escape(@config.base_domain)}\z/
+    def our_record?(rr, base_domain)
+      suffix = /#{Regexp.escape(@config.hostname)}\.#{Regexp.escape(base_domain)}\z/
 
       case rr.data
       when Resolv::DNS::Resource::IN::A, Resolv::DNS::Resource::IN::AAAA

--- a/spec/fixtures/dns_records/exposed_port80_sd.yml
+++ b/spec/fixtures/dns_records/exposed_port80_sd.yml
@@ -1,0 +1,28 @@
+- name: asdfasdfexpo.speccy.sd.example.com
+  type: :A
+  ttl: 60
+  data:
+  - 172.17.0.42
+- name: asdfasdfexpo.speccy.sd.example.com
+  type: :AAAA
+  ttl: 60
+  data:
+  - 2001:db8::42
+- name: exposed80._http._tcp.sd.example.com
+  type: :SRV
+  ttl: 60
+  data:
+  - 0
+  - 0
+  - 80
+  - asdfasdfexpo.speccy.sd.example.com
+- name: exposed80._http._tcp.sd.example.com
+  type: :TXT
+  ttl: 60
+  data:
+  - ""
+- name: _http._tcp.sd.example.com
+  type: :PTR
+  ttl: 60
+  data:
+  - exposed80._http._tcp.sd.example.com

--- a/spec/fixtures/dns_records/published_port80_sd.yml
+++ b/spec/fixtures/dns_records/published_port80_sd.yml
@@ -1,0 +1,18 @@
+- name: pub80._http._tcp.sd.example.com
+  type: :SRV
+  ttl: 60
+  data:
+  - 0
+  - 0
+  - 8080
+  - speccy.sd.example.com
+- name: pub80._http._tcp.sd.example.com
+  type: :TXT
+  ttl: 60
+  data:
+  - ""
+- name: _http._tcp.sd.example.com
+  type: :PTR
+  ttl: 60
+  data:
+  - pub80._http._tcp.sd.example.com


### PR DESCRIPTION
There are other places that use `DDNSSD_BASE_DOMAIN` instead of respecting the per-backend base domains. The System, Container and ServiceInstance classes needed to be refactored a bit to generate the desired DNS records for each backend.

No rush to merge this since I'm testing it in another branch.