### PR TITLE
Use relative names in DNS records

### DIFF
--- a/lib/ddnssd/backend.rb
+++ b/lib/ddnssd/backend.rb
@@ -6,6 +6,8 @@ module DDNSSD
   class Backend
     class InvalidRequest < DDNSSD::Error; end
 
+    PUBLISHABLE_TYPES = [:A, :AAAA, :CNAME, :SRV, :TXT, :PTR]
+
     def self.backend_name
       self.to_s.split("::").last.gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').gsub(/([a-z\d])([A-Z])/, '\1_\2').downcase
     end
@@ -63,7 +65,7 @@ module DDNSSD
 
         case rr.type
         when :A
-          if rr.name =~ /\A(\d+-\d+-\d+-\d+\.)?[^.]+\.#{Regexp.quote(base_domain)}\z/
+          if rr.name =~ /\A(\d+-\d+-\d+-\d+\.)?[^.]+\z/
             # This record represents an IPv4 address that is (or could be) shared
             # amongst many machines; that means we can't remove it now, in case
             # it's used elsewhere.  We'll defer this for another time
@@ -112,7 +114,8 @@ module DDNSSD
     end
 
     def base_domain
-      backend_config["BASE_DOMAIN"] || @config.base_domain
+      # an absolute Name
+      Resolv::DNS::Name.create((backend_config["BASE_DOMAIN"] || @config.base_domain) + '.')
     end
   end
 end

--- a/lib/ddnssd/backend/azure.rb
+++ b/lib/ddnssd/backend/azure.rb
@@ -75,7 +75,7 @@ class DDNSSD::Backend::Azure < DDNSSD::Backend
 
     def dnssd_to_az_name(name)
       # we use relative names, they use relative names, hurray!
-      name
+      name.to_s
     end
 
     def dnssd_to_az_records(records)

--- a/lib/ddnssd/backend/route53.rb
+++ b/lib/ddnssd/backend/route53.rb
@@ -368,13 +368,14 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
   end
 
   def change_for(action, rrset)
+    first = rrset.first
     {
       action: action,
       resource_record_set: {
-        name: "#{rrset.first.name}.#{base_domain}",
-        type: rrset.first.type.to_s,
-        ttl: rrset.first.ttl,
-        resource_records: rrset.map { |rr| { value: rr.value_absolute(base_domain) } }
+        name: first.to_absolute(base_domain).name,
+        type: first.type.to_s,
+        ttl: first.ttl,
+        resource_records: rrset.map { |rr| { value: rr.to_absolute(base_domain).value } }
       }
     }
   end

--- a/lib/ddnssd/backend/route53.rb
+++ b/lib/ddnssd/backend/route53.rb
@@ -45,8 +45,9 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
   class RecordCache
     include Retryable
 
-    def initialize(zone_id, route53, route53_stats, logger)
-      @zone_id, @route53, @route53_stats, @logger = zone_id, route53, route53_stats, logger
+    def initialize(zone_id, route53, route53_stats, logger, base_domain)
+      @zone_id, @route53, @route53_stats, @logger, @base_domain =
+        zone_id, route53, route53_stats, logger, base_domain
 
       blank_cache
     end
@@ -79,10 +80,17 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
       end
     end
 
-    def refresh(name, type)
+    def refresh(rel_name, type)
+      name = "#{rel_name}.#{@base_domain}"
+
       res = retryable do
         @route53_stats.measure(op: "get") do
-          @route53.list_resource_record_sets(hosted_zone_id: @zone_id, start_record_name: name, start_record_type: type.to_s, max_items: 1)
+          @route53.list_resource_record_sets(
+            hosted_zone_id: @zone_id,
+            start_record_name: name,
+            start_record_type: type.to_s,
+            max_items: 1
+          )
         end
       end
 
@@ -91,7 +99,7 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
       if rrset
         import_rrset(rrset)
       else
-        @cache[name][type] = []
+        @cache[rel_name][type] = []
       end
     end
 
@@ -123,14 +131,23 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
     end
 
     def import_rrset(rrset)
-      @cache[rrset.name.chomp(".")][rrset.type.to_sym] = rrset.resource_records.map do |rr|
+      @cache[rrset.name.chomp(".#{@base_domain}.")][rrset.type.to_sym] = rrset.resource_records.map do |rr|
         rrdata = if rrset.type == "TXT"
           Shellwords.shellwords(rr.value)
         else
           rr.value.split(/\s+/).map { |v| v =~ /\A\d+\z/ ? v.to_i : v }
         end
 
-        DDNSSD::DNSRecord.new(rrset.name.chomp("."), rrset.ttl, rrset.type.to_sym, *rrdata)
+        dns_record = DDNSSD::DNSRecord.new(
+          rrset.name, rrset.ttl, rrset.type.to_sym, *rrdata
+        )
+
+        if DDNSSD::Backend::PUBLISHABLE_TYPES.include?(dns_record.type)
+          dns_record.to_relative(@base_domain)
+        else
+          # import SOA and NS as is
+          dns_record
+        end
       end
     end
   end
@@ -150,7 +167,7 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
     @route53 = Aws::Route53::Client.new(region: "fml")
     @route53_stats = Frankenstein::Request.new(:ddnssd_route53, description: "route53", registry: @config.metrics_registry)
 
-    @record_cache = RecordCache.new(@zone_id, @route53, @route53_stats, @logger)
+    @record_cache = RecordCache.new(@zone_id, @route53, @route53_stats, @logger, base_domain)
   end
 
   def dns_records
@@ -354,10 +371,10 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
     {
       action: action,
       resource_record_set: {
-        name: rrset.first.name,
+        name: "#{rrset.first.name}.#{base_domain}",
         type: rrset.first.type.to_s,
         ttl: rrset.first.ttl,
-        resource_records: rrset.map { |rr| { value: rr.value } }
+        resource_records: rrset.map { |rr| { value: rr.value_absolute(base_domain) } }
       }
     }
   end

--- a/lib/ddnssd/backend/route53.rb
+++ b/lib/ddnssd/backend/route53.rb
@@ -145,19 +145,13 @@ class DDNSSD::Backend::Route53 < DDNSSD::Backend
         )
 
         if DDNSSD::Backend::PUBLISHABLE_TYPES.include?(dns_record.type)
-          if [:PTR, :CNAME, :SRV].include?(dns_record.type)
-            value = dns_record.type == :SRV ? dns_record.data.target : dns_record.data.name
-            if value.subdomain_of?(@base_domain)
-              dns_record.to_relative(@base_domain)
-            elsif raise_errors
-              raise RuntimeError,
-                "Can't import #{dns_record.type} record because value isn't a subdomain of #{@base_domain}. #{dns_record.inspect}"
-            else
-              @logger.warn(progname) { "Found a record with a value that isn't a subdomain of #{@base_domain}. Ignoring it. #{dns_record.inspect}" }
-              nil
-            end
-          else
+          if dns_record.subdomain_of?(@base_domain)
             dns_record.to_relative(@base_domain)
+          elsif raise_errors
+            raise RuntimeError,
+              "Can't import #{dns_record.type} record because value isn't a subdomain of #{@base_domain}. #{dns_record.inspect}"
+          else
+            nil
           end
         else
           # import SOA and NS as is

--- a/lib/ddnssd/config.rb
+++ b/lib/ddnssd/config.rb
@@ -46,7 +46,7 @@ module DDNSSD
     def host_dns_record
       @host_dns_record ||= begin
         if @host_ip_address
-          DDNSSD::DNSRecord.new("#{@hostname}.#{@base_domain}", @record_ttl, :A, @host_ip_address)
+          DDNSSD::DNSRecord.new(@hostname, @record_ttl, :A, @host_ip_address)
         else
           nil
         end

--- a/lib/ddnssd/dns_record.rb
+++ b/lib/ddnssd/dns_record.rb
@@ -75,17 +75,8 @@ module DDNSSD
       @name.absolute?
     end
 
-    def value_absolute(base_domain)
-      case @type
-      when :PTR, :SRV, :CNAME
-        "#{value}.#{base_domain}"
-      else
-        value
-      end
-    end
-
     def to_absolute(base_domain)
-      raise InvalidStateError.new('Record is already absolute!') if absolute?
+      return self if absolute?
 
       abs_data =
         case type
@@ -103,7 +94,7 @@ module DDNSSD
     end
 
     def to_relative(base_domain)
-      raise InvalidStateError.new('Record is already relative!') unless absolute?
+      return self unless absolute?
 
       rel_data =
         case type

--- a/lib/ddnssd/dns_record.rb
+++ b/lib/ddnssd/dns_record.rb
@@ -5,8 +5,6 @@ require 'ddnssd/error'
 module DDNSSD
   class DNSRecord
 
-    class InvalidStateError < DDNSSD::Error; end
-
     attr_reader :ttl, :type, :data
 
     def initialize(name, ttl, type, *data)
@@ -73,6 +71,18 @@ module DDNSSD
 
     def absolute?
       @name.absolute?
+    end
+
+    def subdomain_of?(base_domain)
+      raise RuntimeError, "Can't check subdomain of a relative record" unless absolute?
+
+      return false unless @name.subdomain_of?(base_domain)
+
+      if [:PTR, :CNAME, :SRV].include?(@type)
+        (self.type == :SRV ? @data.target : @data.name).subdomain_of?(base_domain)
+      else
+        true
+      end
     end
 
     def to_absolute(base_domain)

--- a/lib/ddnssd/system.rb
+++ b/lib/ddnssd/system.rb
@@ -138,7 +138,7 @@ module DDNSSD
     end
 
     def our_record?(rr)
-      suffix = /#{Regexp.escape(@config.hostname)}\.#{Regexp.escape(@config.base_domain)}\z/
+      suffix = /#{Regexp.escape(@config.hostname)}\z/
 
       case rr.data
       when Resolv::DNS::Resource::IN::A, Resolv::DNS::Resource::IN::AAAA

--- a/lib/freedom_patches/dns_name.rb
+++ b/lib/freedom_patches/dns_name.rb
@@ -16,7 +16,8 @@ class Resolv::DNS::Name
       raise ArgumentError.new("Subdomain mismatch")
     end
 
-    Resolv::DNS::Name.new(self.to_a - other.to_a, false)
+    a = self.to_a
+    Resolv::DNS::Name.new(a.first(a.size - other.to_a.size), false)
   end
 
 end

--- a/lib/freedom_patches/dns_name.rb
+++ b/lib/freedom_patches/dns_name.rb
@@ -1,0 +1,22 @@
+require 'resolv'
+
+class Resolv::DNS::Name
+
+  def +(other)
+    raise ArgumentError.new("Can't add to an absolute name!") if self.absolute?
+    Resolv::DNS::Name.new(self.to_a + other.to_a, other.absolute?)
+  end
+
+  def -(other)
+    unless self.absolute? == other.absolute?
+      raise ArgumentError.new("Both names must be either relative or absolute")
+    end
+
+    unless self.subdomain_of?(other)
+      raise ArgumentError.new("Subdomain mismatch")
+    end
+
+    Resolv::DNS::Name.new(self.to_a - other.to_a, false)
+  end
+
+end

--- a/spec/azure_backend_spec.rb
+++ b/spec/azure_backend_spec.rb
@@ -168,7 +168,7 @@ describe DDNSSD::Backend::Azure do
                                              "properties" => { "TTL" => 42, "ARecords" => [{ "ipv4Address" => "192.0.2.42" }] }))
         expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :A, "192.0.2.42"))
+        backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :A, "192.0.2.42"))
       end
     end
 
@@ -183,7 +183,7 @@ describe DDNSSD::Backend::Azure do
                                              "properties" => { "TTL" => 42, "AAAARecords" => [{ "ipv6Address" => "2001:DB8::42" }] }))
         expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+        backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
       end
     end
 
@@ -197,7 +197,7 @@ describe DDNSSD::Backend::Azure do
                                            match_azure_record("properties" => { "TTL" => 42, "CNAMERecord" => { "cname" => "pgsql.host27.example.com" } }))
         expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("db.example.com", 42, :CNAME, "pgsql.host27.example.com"))
+        backend.publish_record(DDNSSD::DNSRecord.new("db", 42, :CNAME, "pgsql.host27"))
       end
     end
 
@@ -211,14 +211,14 @@ describe DDNSSD::Backend::Azure do
                                            match_azure_record("properties" => { "TTL" => 42, "TXTRecords" => [{ "value" => ["something \"funny\"", "this too"] }] }))
         expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :TXT, 'something "funny"', "this too"))
+        backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :TXT, 'something "funny"', "this too"))
       end
 
       it "works around an azure limitation of blank records by upserting a TXT record with a space" do
         expect(az_client.record_sets).to receive(:create_or_update).with(rg, zone, "faff._http._tcp", "TXT", match_azure_record("properties" => { "TTL" => 42, "TXTRecords" => [{ "value" => [" "] }] }))
         expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :TXT, ""))
+        backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :TXT, ""))
       end
     end
 
@@ -235,7 +235,7 @@ describe DDNSSD::Backend::Azure do
                                              if_none_match: "*")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
         end
       end
 
@@ -243,8 +243,8 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host3.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host3")
           )
         end
 
@@ -253,7 +253,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:update).with(rg, zone, "faff._http._tcp", "SRV", anything, if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
         end
       end
 
@@ -262,9 +262,9 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host3.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host3"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22")
           )
         end
 
@@ -273,7 +273,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:update).with(rg, zone, "faff._http._tcp", "SRV", anything, if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
         end
       end
 
@@ -287,7 +287,7 @@ describe DDNSSD::Backend::Azure do
 
             expect(az_client.record_sets).to receive(:update).with(rg, zone, "faff._http._tcp", "SRV", anything, if_match: "faff_etag").and_return(OpenStruct.new(etag: "other")).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
           end
         end
 
@@ -298,7 +298,7 @@ describe DDNSSD::Backend::Azure do
 
             expect(az_client.record_sets).to receive(:create_or_update).with(rg, zone, "faff._http._tcp", "SRV", anything, if_none_match: "*").and_return(OpenStruct.new(etag: "other")).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
           end
         end
 
@@ -314,7 +314,7 @@ describe DDNSSD::Backend::Azure do
 
             expect(logger).to receive(:error)
 
-            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
           end
         end
       end
@@ -326,7 +326,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:create_or_update).with(rg, zone, "_http._tcp", "PTR", anything, if_none_match: "*")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
         end
       end
 
@@ -334,8 +334,8 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "xyzzy._http._tcp.example.com"),
-            DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "argle._http._tcp.example.com")
+            DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "xyzzy._http._tcp"),
+            DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "argle._http._tcp")
           )
         end
 
@@ -344,7 +344,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:update).with(rg, zone, "_http._tcp", "PTR", anything, if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
         end
       end
 
@@ -352,7 +352,7 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com")
+            DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp")
           )
         end
 
@@ -360,7 +360,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:update).with(rg, zone, "_http._tcp", "PTR", anything, if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
         end
       end
 
@@ -374,7 +374,7 @@ describe DDNSSD::Backend::Azure do
 
             expect(az_client.record_sets).to receive(:update).with(rg, zone, "_http._tcp", "PTR", anything, if_match: "http_ptr_etag").and_return(OpenStruct.new(etag: "other")).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
           end
         end
 
@@ -385,7 +385,7 @@ describe DDNSSD::Backend::Azure do
 
             expect(az_client.record_sets).to receive(:create_or_update).with(rg, zone, "_http._tcp", "PTR", anything, if_none_match: "*").and_return(OpenStruct.new(etag: "other")).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
           end
         end
 
@@ -401,7 +401,7 @@ describe DDNSSD::Backend::Azure do
 
             expect(logger).to receive(:error)
 
-            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
           end
         end
       end
@@ -421,7 +421,7 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42")
           )
         end
 
@@ -429,7 +429,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:delete).with(rg, zone, "abcd1234.flingle", "A", if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
 
@@ -437,9 +437,9 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.1"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.180")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.1"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.180")
           )
         end
 
@@ -449,7 +449,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
 
@@ -458,8 +458,8 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.1"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.180")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.1"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.180")
           )
         end
 
@@ -468,7 +468,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
     end
@@ -478,7 +478,7 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42")
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42")
           )
         end
 
@@ -486,7 +486,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:delete).with(rg, zone, "flingle", "AAAA", if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
         end
       end
 
@@ -494,9 +494,9 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::1"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::180")
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"),
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::180")
           )
         end
 
@@ -506,7 +506,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
         end
       end
 
@@ -514,8 +514,8 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::1"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::180")
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::180")
           )
         end
 
@@ -525,7 +525,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
         end
       end
     end
@@ -535,7 +535,7 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com")
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42")
           )
         end
 
@@ -543,7 +543,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to receive(:delete).with(rg, zone, "flingle", "CNAME", if_match: "etag")
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"))
         end
       end
 
@@ -551,9 +551,9 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host1.example.com"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host180.example.com")
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"),
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host180")
           )
         end
 
@@ -563,7 +563,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"))
         end
       end
 
@@ -571,8 +571,8 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host1.example.com"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host180.example.com")
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host180")
           )
         end
 
@@ -581,7 +581,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"))
         end
       end
     end
@@ -591,8 +591,8 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host2.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host2")
           )
         end
 
@@ -602,7 +602,7 @@ describe DDNSSD::Backend::Azure do
           expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
           expect(az_client.record_sets).to_not receive(:delete)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host2.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host2"))
         end
 
       end
@@ -611,11 +611,11 @@ describe DDNSSD::Backend::Azure do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1")
           )
           backend.instance_variable_get(:@record_cache).set(
             "etag",
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :TXT, "something funny")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :TXT, "something funny")
           )
         end
 
@@ -623,7 +623,7 @@ describe DDNSSD::Backend::Azure do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
               "etag",
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com")
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp")
             )
           end
 
@@ -633,7 +633,7 @@ describe DDNSSD::Backend::Azure do
             expect(az_client.record_sets).to receive(:delete).with(rg, zone, "faff._http._tcp", "TXT", if_match: "etag")
             expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
 
-            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"))
+            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"))
           end
         end
 
@@ -641,8 +641,8 @@ describe DDNSSD::Backend::Azure do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
               "etag",
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "blargh._http._tcp.example.com"),
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com")
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "blargh._http._tcp"),
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp")
             )
           end
 
@@ -653,7 +653,7 @@ describe DDNSSD::Backend::Azure do
             expect(az_client.record_sets).to_not receive(:list_resource_record_sets)
             expect(az_client.record_sets).to_not receive(:delete).with(rg, zone, "_http._tcp", "PTR", if_match: "etag")
 
-            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"))
+            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"))
           end
         end
       end
@@ -661,13 +661,13 @@ describe DDNSSD::Backend::Azure do
 
     context "with a TXT record" do
       it "logs an error" do
-        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x.example.com", 60, :TXT, "")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
+        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x", 60, :TXT, "")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
       end
     end
 
     context "with a PTR record" do
       it "logs an error" do
-        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x.example.com", 60, :PTR, "faff.example.com")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
+        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x", 60, :PTR, "faff")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
       end
     end
 

--- a/spec/backend_spec.rb
+++ b/spec/backend_spec.rb
@@ -18,46 +18,46 @@ describe DDNSSD::Backend do
 
   describe "#publish_record" do
     before(:each) do
-      allow(backend).to receive(:base_domain).and_return("example.com")
+      allow(backend).to receive(:base_domain).and_return(Resolv::DNS::Name.create("example.com."))
     end
 
     it "calls set_record for an A record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :A, "192.0.2.42")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :A, "192.0.2.42")
 
       expect(backend).to receive(:set_record).with(rr)
       backend.publish_record(rr)
     end
 
     it "calls set_record for a AAAA record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :AAAA, "2001:db8::42")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :AAAA, "2001:db8::42")
 
       expect(backend).to receive(:set_record).with(rr)
       backend.publish_record(rr)
     end
 
     it "calls set_record for a TXT record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :TXT, "ohai")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :TXT, "ohai")
 
       expect(backend).to receive(:set_record).with(rr)
       backend.publish_record(rr)
     end
 
     it "calls set_record for a CNAME record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :CNAME, "bar.example.com")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :CNAME, "bar")
 
       expect(backend).to receive(:set_record).with(rr)
       backend.publish_record(rr)
     end
 
     it "calls add_record for a SRV record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :SRV, 0, 0, 8080, "bar.example.com")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :SRV, 0, 0, 8080, "bar")
 
       expect(backend).to receive(:add_record).with(rr)
       backend.publish_record(rr)
     end
 
     it "calls add_record for a PTR record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :PTR, "bar.example.com")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :PTR, "bar")
 
       expect(backend).to receive(:add_record).with(rr)
       backend.publish_record(rr)
@@ -66,59 +66,59 @@ describe DDNSSD::Backend do
 
   describe "#suppress_record" do
     before(:each) do
-      allow(backend).to receive(:base_domain).and_return("example.com")
+      allow(backend).to receive(:base_domain).and_return(Resolv::DNS::Name.create("example.com."))
     end
 
     it "calls remove_record on a per-container IPv4 address" do
-      rr = DDNSSD::DNSRecord.new("abcd1234.foo.example.com", 60, :A, "172.17.0.42")
+      rr = DDNSSD::DNSRecord.new("abcd1234.foo", 60, :A, "172.17.0.42")
 
       expect(backend).to receive(:remove_record).with(rr)
       backend.suppress_record(rr)
     end
 
     it "does not call remove_record on the host's IPv4 address" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :A, "192.0.2.42")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :A, "192.0.2.42")
 
       expect(backend).to_not receive(:remove_record).with(rr)
       backend.suppress_record(rr)
     end
 
     it "does not call remove_record on an IP address record" do
-      rr = DDNSSD::DNSRecord.new("192-0-2-42.foo.example.com", 60, :A, "192.0.2.42")
+      rr = DDNSSD::DNSRecord.new("192-0-2-42.foo", 60, :A, "192.0.2.42")
 
       expect(backend).to_not receive(:remove_record).with(rr)
       backend.suppress_record(rr)
     end
 
     it "calls remove_record on an IPv6 address" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :AAAA, "2001:db8::42")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :AAAA, "2001:db8::42")
 
       expect(backend).to receive(:remove_record).with(rr)
       backend.suppress_record(rr)
     end
 
     it "calls remove_record on a CNAME" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :CNAME, "bar.example.com")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :CNAME, "bar.example.com")
 
       expect(backend).to receive(:remove_record).with(rr)
       backend.suppress_record(rr)
     end
 
     it "calls remove_srv_record on a SRV" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :SRV, 0, 0, 8080, "bar.example.com")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :SRV, 0, 0, 8080, "bar")
 
       expect(backend).to receive(:remove_srv_record).with(rr)
       backend.suppress_record(rr)
     end
 
     it "refuses to deal with a TXT record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :TXT, "ohai")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :TXT, "ohai")
 
       expect { backend.suppress_record(rr) }.to raise_error(DDNSSD::Backend::InvalidRequest)
     end
 
     it "refuses to deal with a PTR record" do
-      rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :PTR, "bar.example.com")
+      rr = DDNSSD::DNSRecord.new("foo", 60, :PTR, "bar")
 
       expect { backend.suppress_record(rr) }.to raise_error(DDNSSD::Backend::InvalidRequest)
     end
@@ -126,12 +126,12 @@ describe DDNSSD::Backend do
 
   describe "#suppress_shared_records" do
     before(:each) do
-      allow(mock_config).to receive(:host_dns_record).and_return(DDNSSD::DNSRecord.new("foo.example.com", 60, :A, "192.0.2.42"))
-      allow(backend).to receive(:base_domain).and_return("example.com")
+      allow(mock_config).to receive(:host_dns_record).and_return(DDNSSD::DNSRecord.new("foo", 60, :A, "192.0.2.42"))
+      allow(backend).to receive(:base_domain).and_return(Resolv::DNS::Name.create("example.com."))
     end
 
     it "calls remove_record on the host's IPv4 address" do
-      host_rr = DDNSSD::DNSRecord.new("foo.example.com", 60, :A, "192.0.2.42")
+      host_rr = DDNSSD::DNSRecord.new("foo", 60, :A, "192.0.2.42")
 
       expect(mock_config).to receive(:host_dns_record).and_return(host_rr)
       expect(backend).to receive(:suppress_record).with(host_rr)
@@ -139,7 +139,7 @@ describe DDNSSD::Backend do
     end
 
     it "calls remove_record on a shared IP address record when removal was previously attempted" do
-      rr = DDNSSD::DNSRecord.new("192-0-2-42.foo.example.com", 60, :A, "192.0.2.42")
+      rr = DDNSSD::DNSRecord.new("192-0-2-42.foo", 60, :A, "192.0.2.42")
 
       expect(backend).to receive(:remove_record).with(rr)
       backend.suppress_record(rr)
@@ -152,7 +152,9 @@ describe DDNSSD::Backend do
       it "gets the base domain from the system config" do
         expect(mock_config).to receive(:base_domain).and_return("example.com")
 
-        expect(backend.__send__(:base_domain)).to eq("example.com")
+        base_domain = backend.__send__(:base_domain)
+        expect(base_domain.to_s).to eq("example.com")
+        expect(base_domain).to be_a(Resolv::DNS::Name)
       end
     end
 
@@ -163,7 +165,9 @@ describe DDNSSD::Backend do
           .and_return("backend" => { "BASE_DOMAIN" => "example.net" })
         expect(mock_config).to_not receive(:base_domain)
 
-        expect(backend.__send__(:base_domain)).to eq("example.net")
+        base_domain = backend.__send__(:base_domain)
+        expect(base_domain.to_s).to eq("example.net")
+        expect(base_domain).to be_a(Resolv::DNS::Name)
       end
     end
   end

--- a/spec/dns_name_spec.rb
+++ b/spec/dns_name_spec.rb
@@ -57,5 +57,11 @@ describe Resolv::DNS::Name do
         Resolv::DNS::Name.create('foo.bar.com.') - Resolv::DNS::Name.create('baz.com.')
       }.to raise_error(ArgumentError)
     end
+
+    it "subtracts from the end" do
+      diff = Resolv::DNS::Name.create('my-server._tcp.my-server.example.com.') -
+        Resolv::DNS::Name.create('my-server.example.com.')
+      expect(diff.to_s).to eq('my-server._tcp')
+    end
   end
 end

--- a/spec/dns_name_spec.rb
+++ b/spec/dns_name_spec.rb
@@ -1,0 +1,61 @@
+require 'freedom_patches/dns_name'
+
+describe Resolv::DNS::Name do
+  describe "+" do
+    it "adds two relative names and creates a relative name" do
+      sum = Resolv::DNS::Name.create('foo') + Resolv::DNS::Name.create('bar')
+      expect(sum.to_s).to eq('foo.bar')
+      expect(sum).to_not be_absolute
+    end
+
+    it "adds relative to absolute and creates an absolute name" do
+      sum = Resolv::DNS::Name.create('foo') + Resolv::DNS::Name.create('bar.com.')
+      expect(sum.to_s).to eq('foo.bar.com')
+      expect(sum).to be_absolute
+    end
+
+    it "raises error when adding absolute to relative" do
+      expect {
+        Resolv::DNS::Name.create('bar.com.') + Resolv::DNS::Name.create('foo')
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises error when adding absolute to absolute" do
+      expect {
+        Resolv::DNS::Name.create('bar.com.') + Resolv::DNS::Name.create('foo.com.')
+      }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "-" do
+    it "subtracts two relative names and creates a relative name" do
+      diff = Resolv::DNS::Name.create('foo.bar') - Resolv::DNS::Name.create('bar')
+      expect(diff.to_s).to eq('foo')
+      expect(diff).to_not be_absolute
+    end
+
+    it "subtracts absolute name from an absolute name to create a relative name" do
+      diff = Resolv::DNS::Name.create('foo.bar.com.') - Resolv::DNS::Name.create('bar.com.')
+      expect(diff.to_s).to eq('foo')
+      expect(diff).to_not be_absolute
+    end
+
+    it "raises an error when subtracting relative from absolute name" do
+      expect {
+        Resolv::DNS::Name.create('foo.bar.com.') - Resolv::DNS::Name.create('com')
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises an error when subtracting absolute from relative name" do
+      expect {
+        Resolv::DNS::Name.create('foo.bar.com') - Resolv::DNS::Name.create('bar.com.')
+      }.to raise_error(ArgumentError)
+    end
+
+    it "raises error if not a subdomain of what's being subtracted" do
+      expect {
+        Resolv::DNS::Name.create('foo.bar.com.') - Resolv::DNS::Name.create('baz.com.')
+      }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/dns_record_spec.rb
+++ b/spec/dns_record_spec.rb
@@ -26,10 +26,8 @@ describe DDNSSD::DNSRecord do
   describe '#to_absolute' do
     let(:base_domain) { Resolv::DNS::Name.create('example.com.') }
 
-    it 'raises error on an absolute record' do
-      expect {
-        abs_record.to_absolute(base_domain)
-      }.to raise_error(DDNSSD::DNSRecord::InvalidStateError)
+    it 'returns an absolute record unchanged' do
+      expect(abs_record.to_absolute(base_domain)).to eq(abs_record)
     end
 
     it 'works on relative A record' do
@@ -82,10 +80,8 @@ describe DDNSSD::DNSRecord do
   describe '#to_relative' do
     let(:base_domain) { Resolv::DNS::Name.create('example.com.') }
 
-    it 'raises error on a relative record' do
-      expect {
-        rel_record.to_relative(base_domain)
-      }.to raise_error(DDNSSD::DNSRecord::InvalidStateError)
+    it 'returns a relative record unchanged' do
+      expect(rel_record.to_relative(base_domain)).to eq(rel_record)
     end
 
     it 'works on absolute A record' do

--- a/spec/dns_record_spec.rb
+++ b/spec/dns_record_spec.rb
@@ -600,4 +600,74 @@ describe DDNSSD::DNSRecord do
       end
     end
   end
+
+  describe '#subdomain_of?' do
+    let(:base_domain) { Resolv::DNS::Name.create('example.com.') }
+
+    it 'raises an error on a relative record' do
+      expect {
+        DDNSSD::DNSRecord.new("_foo._tcp", 42, :PTR, "_bar._foo._tcp").subdomain_of?(base_domain)
+      }.to raise_error(RuntimeError)
+    end
+
+    it "returns true on A record with that's a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.example.com.", 42, :A, "192.0.2.42").subdomain_of?(base_domain)).to eq(true)
+    end
+
+    it "returns false on A record that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.freedom.com.", 42, :A, "192.0.2.42").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns true on AAAA record with that's a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.example.com.", 42, :AAAA, "2001:db8::42").subdomain_of?(base_domain)).to eq(true)
+    end
+
+    it "returns false on AAAA record that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.freedom.com.", 42, :AAAA, "2001:db8::42").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns true on CNAME record with that's a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.example.com.", 42, :CNAME, "host1.example.com").subdomain_of?(base_domain)).to eq(true)
+    end
+
+    it "returns false on CNAME record that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.freedom.com.", 42, :CNAME, "host1.freedom.com").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns false on CNAME record with value that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("foo.example.com.", 42, :CNAME, "host1.freedom.com").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns true on SRV record with that's a subdomain" do
+      expect(DDNSSD::DNSRecord.new("bar._foo._tcp.example.com.", 42, :SRV, 0, 0, 8080, "bar1.example.com").subdomain_of?(base_domain)).to eq(true)
+    end
+
+    it "returns false on SRV record that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("bar._foo._tcp.freedom.com.", 42, :SRV, 0, 0, 8080, "bar1.freedom.com").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns false on SRV record with value that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("bar._foo._tcp.example.com.", 42, :SRV, 0, 0, 8080, "bar1.freedom.com").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns true on TXT record with that's a subdomain" do
+      expect(DDNSSD::DNSRecord.new("bar._foo._tcp.example.com.", 42, :TXT, "nobugs").subdomain_of?(base_domain)).to eq(true)
+    end
+
+    it "returns false on TXT record that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("bar._foo._tcp.freedom.com.", 42, :TXT, "nobugs").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns true on PTR record with that's a subdomain" do
+      expect(DDNSSD::DNSRecord.new("_foo._tcp.example.com.", 42, :PTR, "bar._foo._tcp.example.com").subdomain_of?(base_domain)).to eq(true)
+    end
+
+    it "returns false on PTR record that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("_foo._tcp.freedom.com.", 42, :PTR, "bar._foo._tcp.freedom.com").subdomain_of?(base_domain)).to eq(false)
+    end
+
+    it "returns false on PTR record with value that's not a subdomain" do
+      expect(DDNSSD::DNSRecord.new("_foo._tcp.example.com.", 42, :PTR, "bar._foo._tcp.freedom.com").subdomain_of?(base_domain)).to eq(false)
+    end
+  end
 end

--- a/spec/dns_record_spec.rb
+++ b/spec/dns_record_spec.rb
@@ -3,19 +3,189 @@ require_relative './spec_helper'
 require 'ddnssd/dns_record'
 
 describe DDNSSD::DNSRecord do
-  let(:record) { DDNSSD::DNSRecord.new("foo.example.com", 42, :A, "192.0.2.42") }
+  let(:abs_record) { DDNSSD::DNSRecord.new("foo.example.com.", 42, :A, "192.0.2.42") }
+  let(:rel_record) { DDNSSD::DNSRecord.new("foo", 42, :A, "192.0.2.42") }
+  let(:record) { abs_record }
 
   describe "#name" do
-    it "returns the record's name" do
-      expect(record.name).to eq("foo.example.com")
-    end
-
-    context "when passed a Resolv::DNS::Name" do
-      let(:record) { DDNSSD::DNSRecord.new(Resolv::DNS::Name.create("foo.example.com"), 42, :A, "192.0.2.42") }
-
-      it "returns the string name" do
+    context 'absolute' do
+      it "returns the record's name" do
         expect(record.name).to eq("foo.example.com")
       end
+
+      context "when passed a Resolv::DNS::Name" do
+        let(:record) { DDNSSD::DNSRecord.new(Resolv::DNS::Name.create("foo.example.com"), 42, :A, "192.0.2.42") }
+
+        it "returns the string name" do
+          expect(record.name).to eq("foo.example.com")
+        end
+      end
+    end
+  end
+
+  describe '#to_absolute' do
+    let(:base_domain) { Resolv::DNS::Name.create('example.com.') }
+
+    it 'raises error on an absolute record' do
+      expect {
+        abs_record.to_absolute(base_domain)
+      }.to raise_error(DDNSSD::DNSRecord::InvalidStateError)
+    end
+
+    it 'works on relative A record' do
+      rr = DDNSSD::DNSRecord.new("foo", 42, :A, "192.0.2.42")
+      relrr = rr.to_absolute(base_domain)
+      expect(relrr.name).to eq("foo.example.com")
+    end
+
+    it 'works on relative AAAA record' do
+      rr = DDNSSD::DNSRecord.new("foo", 42, :AAAA, "2001:db8::42")
+      relrr = rr.to_absolute(base_domain)
+      expect(relrr.name).to eq("foo.example.com")
+    end
+
+    it 'works on relative CNAME record' do
+      rr = DDNSSD::DNSRecord.new("foo", 42, :CNAME, "host1")
+      relrr = rr.to_absolute(base_domain)
+      expect(relrr.name).to eq("foo.example.com")
+      expect(relrr.data.name.to_s).to eq("host1.example.com")
+    end
+
+    it 'works on relative SRV record' do
+      rr = DDNSSD::DNSRecord.new("bar._foo._tcp", 42, :SRV, 0, 0, 8080, "bar1")
+      relrr = rr.to_absolute(base_domain)
+      expect(relrr.name).to eq("bar._foo._tcp.example.com")
+      expect(relrr.data.target.to_s).to eq("bar1.example.com")
+    end
+
+    it 'works on relative TXT record' do
+      rr = DDNSSD::DNSRecord.new("bar._foo._tcp", 42, :TXT, "nobugs")
+      relrr = rr.to_absolute(base_domain)
+      expect(relrr.name).to eq("bar._foo._tcp.example.com")
+      expect(relrr.data.data).to eq("nobugs")
+    end
+
+    it 'works on relative PTR record' do
+      rr = DDNSSD::DNSRecord.new("_foo._tcp", 42, :PTR, "bar._foo._tcp")
+      relrr = rr.to_absolute(base_domain)
+      expect(relrr.name).to eq("_foo._tcp.example.com")
+      expect(relrr.data.name.to_s).to eq("bar._foo._tcp.example.com")
+    end
+
+    it 'raises error on NS record' do
+      expect {
+        DDNSSD::DNSRecord.new("example.com", 60, :NS, "ns1.example.com").to_absolute(base_domain)
+      }.to raise_error(RuntimeError)
+    end
+  end
+
+  describe '#to_relative' do
+    let(:base_domain) { Resolv::DNS::Name.create('example.com.') }
+
+    it 'raises error on a relative record' do
+      expect {
+        rel_record.to_relative(base_domain)
+      }.to raise_error(DDNSSD::DNSRecord::InvalidStateError)
+    end
+
+    it 'works on absolute A record' do
+      rr = DDNSSD::DNSRecord.new("foo.example.com.", 42, :A, "192.0.2.42")
+      relrr = rr.to_relative(base_domain)
+      expect(relrr.name).to eq("foo")
+    end
+
+    it 'works on absolute AAAA record' do
+      rr = DDNSSD::DNSRecord.new("foo.example.com.", 42, :AAAA, "2001:db8::42")
+      relrr = rr.to_relative(base_domain)
+      expect(relrr.name).to eq("foo")
+    end
+
+    it 'works on absolute CNAME record' do
+      rr = DDNSSD::DNSRecord.new("foo.example.com.", 42, :CNAME, "host1.example.com.")
+      relrr = rr.to_relative(base_domain)
+      expect(relrr.name).to eq("foo")
+      expect(relrr.data.name.to_s).to eq("host1")
+    end
+
+    it 'works on absolute SRV record' do
+      rr = DDNSSD::DNSRecord.new("bar._foo._tcp.example.com.", 42, :SRV, 0, 0, 8080, "bar1.example.com.")
+      relrr = rr.to_relative(base_domain)
+      expect(relrr.name).to eq("bar._foo._tcp")
+      expect(relrr.data.target.to_s).to eq("bar1")
+    end
+
+    it 'works on absolute TXT record' do
+      rr = DDNSSD::DNSRecord.new("bar._foo._tcp.example.com.", 42, :TXT, "nobugs")
+      relrr = rr.to_relative(base_domain)
+      expect(relrr.name).to eq("bar._foo._tcp")
+      expect(relrr.data.data).to eq("nobugs")
+    end
+
+    it 'works on absolute PTR record' do
+      rr = DDNSSD::DNSRecord.new("_foo._tcp.example.com.", 42, :PTR, "bar._foo._tcp.example.com.")
+      relrr = rr.to_relative(base_domain)
+      expect(relrr.name).to eq("_foo._tcp")
+      expect(relrr.data.name.to_s).to eq("bar._foo._tcp")
+    end
+
+    it 'raises error on NS record' do
+      expect {
+        DDNSSD::DNSRecord.new("example.com.", 60, :NS, "ns1.example.com.").to_relative(base_domain)
+      }.to raise_error(RuntimeError)
+    end
+
+    it 'raises error if A record is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("foo.example.org.", 42, :A, "192.0.2.42").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if AAAA record is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("foo.example.org.", 42, :AAAA, "2001:db8::42").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if CNAME record is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("foo.example.org.", 42, :CNAME, "host1.example.org.").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if CNAME record value is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("foo.example.com.", 42, :CNAME, "host1.example.org.").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if SRV record is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("bar._foo._tcp.example.org.", 42, :SRV, 0, 0, 8080, "bar1.example.org.").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if SRV record target is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("bar._foo._tcp.example.com.", 42, :SRV, 0, 0, 8080, "bar1.example.org.").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if TXT record is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("bar._foo._tcp.example.org.", 42, :TXT, "nobugs").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if PTR record is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("_foo._tcp.example.org.", 42, :PTR, "bar._foo._tcp.example.org.").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
+    end
+
+    it 'raises error if PTR record target is not a subdomain of given base domain' do
+      expect {
+        DDNSSD::DNSRecord.new("_foo._tcp.example.com.", 42, :PTR, "bar._foo._tcp.example.org.").to_relative(base_domain)
+      }.to raise_error(ArgumentError)
     end
   end
 
@@ -25,144 +195,412 @@ describe DDNSSD::DNSRecord do
     end
   end
 
-  context "with an A record" do
-    let(:record) { DDNSSD::DNSRecord.new("foo.example.com", 42, :A, "192.0.2.42") }
+  describe '#new' do
+    context 'absolute records' do
+      context "with an A record" do
+        let(:record) { DDNSSD::DNSRecord.new("foo.example.com.", 42, :A, "192.0.2.42") }
 
-    describe "#data" do
-      it "is the appropriate class" do
-        expect(record.data).to be_a(Resolv::DNS::Resource::IN::A)
+        it "is absolute" do
+          expect(record).to be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('foo.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::A)
+          end
+
+          it "holds the provided address" do
+            expect(record.data.address.to_s).to eq("192.0.2.42")
+          end
+        end
+
+        describe "#value" do
+          it "returns the address" do
+            expect(record.value).to eq("192.0.2.42")
+          end
+        end
       end
 
-      it "holds the provided address" do
-        expect(record.data.address.to_s).to eq("192.0.2.42")
+      context "with a AAAA record" do
+        let(:record) { DDNSSD::DNSRecord.new("foo.example.com.", 42, :AAAA, "2001:db8::42") }
+
+        it "is absolute" do
+          expect(record).to be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('foo.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::AAAA)
+          end
+
+          it "holds the provided address" do
+            expect(record.data.address.to_s).to eq("2001:DB8::42")
+          end
+        end
+
+        describe "#value" do
+          it "returns the address" do
+            expect(record.value).to eq("2001:DB8::42")
+          end
+        end
+      end
+
+      context "with a SRV record" do
+        let(:record) { DDNSSD::DNSRecord.new("_bar._foo._tcp.example.com.", 42, :SRV, 2, 4, 8, "bar.example.com.") }
+
+        it "is absolute" do
+          expect(record).to be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('_bar._foo._tcp.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::SRV)
+          end
+
+          it "holds the provided priority" do
+            expect(record.data.priority).to eq(2)
+          end
+
+          it "holds the provided weight" do
+            expect(record.data.weight).to eq(4)
+          end
+
+          it "holds the provided port" do
+            expect(record.data.port).to eq(8)
+          end
+
+          it "holds the provided target" do
+            expect(record.data.target.to_s).to eq("bar.example.com")
+          end
+        end
+
+        describe "#value" do
+          it "returns the consolidated record data" do
+            expect(record.value).to eq("2 4 8 bar.example.com")
+          end
+        end
+      end
+
+      context "with a PTR record" do
+        let(:record) { DDNSSD::DNSRecord.new("_foo._tcp.example.com.", 42, :PTR, "_bar._foo._tcp.example.com.") }
+
+        it "is absolute" do
+          expect(record).to be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('_foo._tcp.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::PTR)
+          end
+
+          it "holds the provided name" do
+            expect(record.data.name.to_s).to eq("_bar._foo._tcp.example.com")
+          end
+        end
+
+        describe "#value" do
+          it "returns the target" do
+            expect(record.value).to eq("_bar._foo._tcp.example.com")
+          end
+        end
+      end
+
+      context "with a TXT record" do
+        let(:record) { DDNSSD::DNSRecord.new("_bar._foo._tcp.example.com.", 42, :TXT, 'something "funny"', "this too") }
+
+        it "is absolute" do
+          expect(record).to be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('_bar._foo._tcp.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::TXT)
+          end
+
+          it "holds the provided strings" do
+            expect(record.data.strings).to eq(['something "funny"', "this too"])
+          end
+        end
+
+        describe "#value" do
+          it "returns the quoted strings" do
+            expect(record.value).to eq('"something \"funny\"" "this too"')
+          end
+        end
+      end
+
+      context "with a CNAME record" do
+        let(:record) { DDNSSD::DNSRecord.new("something.example.com.", 42, :CNAME, "guy-incognito.example.com.") }
+
+        it "is absolute" do
+          expect(record).to be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('something.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::CNAME)
+          end
+
+          it "holds the provided name" do
+            expect(record.data.name.to_s).to eq("guy-incognito.example.com")
+          end
+        end
+
+        describe "#value" do
+          it "returns the target" do
+            expect(record.value).to eq("guy-incognito.example.com")
+          end
+        end
+      end
+
+      context "with a mystery record" do
+        let(:record) { DDNSSD::DNSRecord.new("example.com", 60, :NS, "ns1.example.com") }
+
+        describe "#value" do
+          it "raises an exception" do
+            expect { record.value }.to raise_error(RuntimeError)
+          end
+        end
       end
     end
 
-    describe "#value" do
-      it "returns the address" do
-        expect(record.value).to eq("192.0.2.42")
-      end
-    end
-  end
+    context 'relative records' do
+      context "with an A record" do
+        let(:record) { DDNSSD::DNSRecord.new("foo.example.com", 42, :A, "192.0.2.42") }
 
-  context "with a AAAA record" do
-    let(:record) { DDNSSD::DNSRecord.new("foo.example.com", 42, :AAAA, "2001:db8::42") }
+        it "is relative" do
+          expect(record).to_not be_absolute
+        end
 
-    describe "#data" do
-      it "is the appropriate class" do
-        expect(record.data).to be_a(Resolv::DNS::Resource::IN::AAAA)
-      end
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('foo.example.com')
+          end
+        end
 
-      it "holds the provided address" do
-        expect(record.data.address.to_s).to eq("2001:DB8::42")
-      end
-    end
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::A)
+          end
 
-    describe "#value" do
-      it "returns the address" do
-        expect(record.value).to eq("2001:DB8::42")
-      end
-    end
-  end
+          it "holds the provided address" do
+            expect(record.data.address.to_s).to eq("192.0.2.42")
+          end
+        end
 
-  context "with a SRV record" do
-    let(:record) { DDNSSD::DNSRecord.new("_bar._foo._tcp.example.com", 42, :SRV, 2, 4, 8, "bar.example.com") }
-
-    describe "#data" do
-      it "is the appropriate class" do
-        expect(record.data).to be_a(Resolv::DNS::Resource::IN::SRV)
+        describe "#value" do
+          it "returns the address" do
+            expect(record.value).to eq("192.0.2.42")
+          end
+        end
       end
 
-      it "holds the provided priority" do
-        expect(record.data.priority).to eq(2)
+      context "with a AAAA record" do
+        let(:record) { DDNSSD::DNSRecord.new("foo.example.com", 42, :AAAA, "2001:db8::42") }
+
+        it "is relative" do
+          expect(record).to_not be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('foo.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::AAAA)
+          end
+
+          it "holds the provided address" do
+            expect(record.data.address.to_s).to eq("2001:DB8::42")
+          end
+        end
+
+        describe "#value" do
+          it "returns the address" do
+            expect(record.value).to eq("2001:DB8::42")
+          end
+        end
       end
 
-      it "holds the provided weight" do
-        expect(record.data.weight).to eq(4)
+      context "with a SRV record" do
+        let(:record) { DDNSSD::DNSRecord.new("_bar._foo._tcp.example.com", 42, :SRV, 2, 4, 8, "bar.example.com") }
+
+        it "is relative" do
+          expect(record).to_not be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('_bar._foo._tcp.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::SRV)
+          end
+
+          it "holds the provided priority" do
+            expect(record.data.priority).to eq(2)
+          end
+
+          it "holds the provided weight" do
+            expect(record.data.weight).to eq(4)
+          end
+
+          it "holds the provided port" do
+            expect(record.data.port).to eq(8)
+          end
+
+          it "holds the provided target" do
+            expect(record.data.target.to_s).to eq("bar.example.com")
+          end
+        end
+
+        describe "#value" do
+          it "returns the consolidated record data" do
+            expect(record.value).to eq("2 4 8 bar.example.com")
+          end
+        end
       end
 
-      it "holds the provided port" do
-        expect(record.data.port).to eq(8)
+      context "with a PTR record" do
+        let(:record) { DDNSSD::DNSRecord.new("_foo._tcp.example.com", 42, :PTR, "_bar._foo._tcp.example.com") }
+
+        it "is relative" do
+          expect(record).to_not be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('_foo._tcp.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::PTR)
+          end
+
+          it "holds the provided name" do
+            expect(record.data.name.to_s).to eq("_bar._foo._tcp.example.com")
+          end
+        end
+
+        describe "#value" do
+          it "returns the target" do
+            expect(record.value).to eq("_bar._foo._tcp.example.com")
+          end
+        end
       end
 
-      it "holds the provided target" do
-        expect(record.data.target.to_s).to eq("bar.example.com")
-      end
-    end
+      context "with a TXT record" do
+        let(:record) { DDNSSD::DNSRecord.new("_bar._foo._tcp.example.com", 42, :TXT, 'something "funny"', "this too") }
 
-    describe "#value" do
-      it "returns the consolidated record data" do
-        expect(record.value).to eq("2 4 8 bar.example.com")
-      end
-    end
-  end
+        it "is relative" do
+          expect(record).to_not be_absolute
+        end
 
-  context "with a PTR record" do
-    let(:record) { DDNSSD::DNSRecord.new("_foo._tcp.example.com", 42, :PTR, "_bar._foo._tcp.example.com") }
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('_bar._foo._tcp.example.com')
+          end
+        end
 
-    describe "#data" do
-      it "is the appropriate class" do
-        expect(record.data).to be_a(Resolv::DNS::Resource::IN::PTR)
-      end
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::TXT)
+          end
 
-      it "holds the provided name" do
-        expect(record.data.name).to eq("_bar._foo._tcp.example.com")
-      end
-    end
+          it "holds the provided strings" do
+            expect(record.data.strings).to eq(['something "funny"', "this too"])
+          end
+        end
 
-    describe "#value" do
-      it "returns the target" do
-        expect(record.value).to eq("_bar._foo._tcp.example.com")
-      end
-    end
-  end
-
-  context "with a TXT record" do
-    let(:record) { DDNSSD::DNSRecord.new("_bar._foo._tcp.example.com", 42, :TXT, 'something "funny"', "this too") }
-
-    describe "#data" do
-      it "is the appropriate class" do
-        expect(record.data).to be_a(Resolv::DNS::Resource::IN::TXT)
+        describe "#value" do
+          it "returns the quoted strings" do
+            expect(record.value).to eq('"something \"funny\"" "this too"')
+          end
+        end
       end
 
-      it "holds the provided strings" do
-        expect(record.data.strings).to eq(['something "funny"', "this too"])
+      context "with a CNAME record" do
+        let(:record) { DDNSSD::DNSRecord.new("something.example.com", 42, :CNAME, "guy-incognito.example.com") }
+
+        it "is relative" do
+          expect(record).to_not be_absolute
+        end
+
+        describe '#name' do
+          it 'is the absolute name' do
+            expect(record.name).to eq('something.example.com')
+          end
+        end
+
+        describe "#data" do
+          it "is the appropriate class" do
+            expect(record.data).to be_a(Resolv::DNS::Resource::IN::CNAME)
+          end
+
+          it "holds the provided name" do
+            expect(record.data.name.to_s).to eq("guy-incognito.example.com")
+          end
+        end
+
+        describe "#value" do
+          it "returns the target" do
+            expect(record.value).to eq("guy-incognito.example.com")
+          end
+        end
       end
-    end
 
-    describe "#value" do
-      it "returns the quoted strings" do
-        expect(record.value).to eq('"something \"funny\"" "this too"')
-      end
-    end
-  end
+      context "with a mystery record" do
+        let(:record) { DDNSSD::DNSRecord.new("example.com", 60, :NS, "ns1.example.com") }
 
-  context "with a CNAME record" do
-    let(:record) { DDNSSD::DNSRecord.new("something.example.com", 42, :CNAME, "guy-incognito.example.com") }
-
-    describe "#data" do
-      it "is the appropriate class" do
-        expect(record.data).to be_a(Resolv::DNS::Resource::IN::CNAME)
-      end
-
-      it "holds the provided name" do
-        expect(record.data.name).to eq("guy-incognito.example.com")
-      end
-    end
-
-    describe "#value" do
-      it "returns the target" do
-        expect(record.value).to eq("guy-incognito.example.com")
-      end
-    end
-  end
-
-  context "with a mystery record" do
-    let(:record) { DDNSSD::DNSRecord.new("example.com", 60, :NS, "ns1.example.com") }
-
-    describe "#value" do
-      it "raises an exception" do
-        expect { record.value }.to raise_error(RuntimeError)
+        describe "#value" do
+          it "raises an exception" do
+            expect { record.value }.to raise_error(RuntimeError)
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/dns_records/exposed_port80.yml
+++ b/spec/fixtures/dns_records/exposed_port80.yml
@@ -1,28 +1,28 @@
-- name: asdfasdfexpo.speccy.example.com
+- name: asdfasdfexpo.speccy
   type: :A
   ttl: 60
   data:
   - 172.17.0.42
-- name: asdfasdfexpo.speccy.example.com
+- name: asdfasdfexpo.speccy
   type: :AAAA
   ttl: 60
   data:
   - 2001:db8::42
-- name: exposed80._http._tcp.example.com
+- name: exposed80._http._tcp
   type: :SRV
   ttl: 60
   data:
   - 0
   - 0
   - 80
-  - asdfasdfexpo.speccy.example.com
-- name: exposed80._http._tcp.example.com
+  - asdfasdfexpo.speccy
+- name: exposed80._http._tcp
   type: :TXT
   ttl: 60
   data:
   - ""
-- name: _http._tcp.example.com
+- name: _http._tcp
   type: :PTR
   ttl: 60
   data:
-  - exposed80._http._tcp.example.com
+  - exposed80._http._tcp

--- a/spec/fixtures/dns_records/exposed_port_multiple_instances.yml
+++ b/spec/fixtures/dns_records/exposed_port_multiple_instances.yml
@@ -1,56 +1,56 @@
-- name: asdfasdfexpo.speccy.example.com
+- name: asdfasdfexpo.speccy
   type: :A
   ttl: 60
   data:
   - 172.17.0.42
-- name: asdfasdfexpo.speccy.example.com
+- name: asdfasdfexpo.speccy
   type: :AAAA
   ttl: 60
   data:
   - 2001:db8::42
-- name: exposed80mi._http._tcp.example.com
+- name: exposed80mi._http._tcp
   type: :SRV
   ttl: 60
   data:
   - 0
   - 0
   - 80
-  - asdfasdfexpo.speccy.example.com
-- name: exposed80mi._http._tcp.example.com
+  - asdfasdfexpo.speccy
+- name: exposed80mi._http._tcp
   type: :TXT
   ttl: 60
   data:
   - ""
-- name: _http._tcp.example.com
+- name: _http._tcp
   type: :PTR
   ttl: 60
   data:
-  - exposed80mi._http._tcp.example.com
-- name: asdfasdfexpo.speccy.example.com
+  - exposed80mi._http._tcp
+- name: asdfasdfexpo.speccy
   type: :A
   ttl: 60
   data:
   - 172.17.0.42
-- name: asdfasdfexpo.speccy.example.com
+- name: asdfasdfexpo.speccy
   type: :AAAA
   ttl: 60
   data:
   - 2001:db8::42
-- name: blah._http._tcp.example.com
+- name: blah._http._tcp
   type: :SRV
   ttl: 60
   data:
   - 0
   - 0
   - 80
-  - asdfasdfexpo.speccy.example.com
-- name: blah._http._tcp.example.com
+  - asdfasdfexpo.speccy
+- name: blah._http._tcp
   type: :TXT
   ttl: 60
   data:
   - ""
-- name: _http._tcp.example.com
+- name: _http._tcp
   type: :PTR
   ttl: 60
   data:
-  - blah._http._tcp.example.com
+  - blah._http._tcp

--- a/spec/fixtures/dns_records/host_port80.yml
+++ b/spec/fixtures/dns_records/host_port80.yml
@@ -1,18 +1,18 @@
-- name: host_port80._http._tcp.example.com
+- name: host_port80._http._tcp
   type: :SRV
   ttl: 60
   data:
   - 0
   - 0
   - 80
-  - speccy.example.com
-- name: host_port80._http._tcp.example.com
+  - speccy
+- name: host_port80._http._tcp
   type: :TXT
   ttl: 60
   data:
   - ""
-- name: _http._tcp.example.com
+- name: _http._tcp
   type: :PTR
   ttl: 60
   data:
-  - host_port80._http._tcp.example.com
+  - host_port80._http._tcp

--- a/spec/fixtures/dns_records/other_machine.yml
+++ b/spec/fixtures/dns_records/other_machine.yml
@@ -1,13 +1,13 @@
-- name: zomg.someone-else.example.com
+- name: zomg.someone-else
   type: :A
   ttl: 60
   data:
   - 192.0.2.123
-- name: pub80._http._tcp.example.com
+- name: pub80._http._tcp
   type: :SRV
   ttl: 60
   data:
   - 0
   - 0
   - 8080
-  - zomg.someone-else.example.com
+  - zomg.someone-else

--- a/spec/fixtures/dns_records/published_port80.yml
+++ b/spec/fixtures/dns_records/published_port80.yml
@@ -1,18 +1,18 @@
-- name: pub80._http._tcp.example.com
+- name: pub80._http._tcp
   type: :SRV
   ttl: 60
   data:
   - 0
   - 0
   - 8080
-  - speccy.example.com
-- name: pub80._http._tcp.example.com
+  - speccy
+- name: pub80._http._tcp
   type: :TXT
   ttl: 60
   data:
   - ""
-- name: _http._tcp.example.com
+- name: _http._tcp
   type: :PTR
   ttl: 60
   data:
-  - pub80._http._tcp.example.com
+  - pub80._http._tcp

--- a/spec/fixtures/route53_responses/page_of_records_1_of_2.yml
+++ b/spec/fixtures/route53_responses/page_of_records_1_of_2.yml
@@ -14,7 +14,7 @@
   :resource_records:
   - :value: ns1.example.com.
   - :value: ns2.example.com.
-- :name: foo.example.com
+- :name: foo.example.com.
   :type: A
   :ttl: 60
   :resource_records:

--- a/spec/fixtures/route53_responses/wrong_subdomain.yml
+++ b/spec/fixtures/route53_responses/wrong_subdomain.yml
@@ -1,0 +1,44 @@
+:is_truncated: false
+:max_items: 100
+:resource_record_sets:
+- :name: example.com.
+  :type: SOA
+  :ttl: 60
+  :resource_records:
+  - :value: ns1.example.com hostmaster.example.com 1 1 1 1 1
+- :name: example.com.
+  :type: NS
+  :ttl: 60
+  :resource_records:
+  - :value: ns1.example.com.
+  - :value: ns2.example.com.
+- :name: foo.example.com.
+  :type: A
+  :ttl: 60
+  :resource_records:
+  - :value: 192.0.2.42
+- :name: foo.example.com.
+  :type: AAAA
+  :ttl: 60
+  :resource_records:
+  - :value: 2001:db8::42
+- :name: bar._http._tcp.example.com.
+  :type: SRV
+  :ttl: 60
+  :resource_records:
+  - :value: 0 0 8080 foo.eggsample.com
+- :name: bar._http._tcp.example.com.
+  :type: TXT
+  :ttl: 60
+  :resource_records:
+  - :value: '""'
+- :name: _http._tcp.example.com.
+  :type: PTR
+  :ttl: 60
+  :resource_records:
+  - :value: bar._http._tcp.eggsample.com
+- :name: bar.example.com.
+  :type: CNAME
+  :ttl: 60
+  :resource_records:
+  - :value: foo.eggsample.com

--- a/spec/log_backend_spec.rb
+++ b/spec/log_backend_spec.rb
@@ -25,17 +25,17 @@ describe DDNSSD::Backend::Log do
 
   describe "#publish_record" do
     it "logs the publish call" do
-      expect(logger).to receive(:info) { |_, &blk| expect(blk.call).to match(/publish.*flingle.example.com/i) }
+      expect(logger).to receive(:info) { |_, &blk| expect(blk.call).to match(/publish.*flingle/i) }
 
-      backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :A, "192.0.2.42"))
+      backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :A, "192.0.2.42"))
     end
   end
 
   describe "#suppress_record" do
     it "logs the suppress call" do
-      expect(logger).to receive(:info) { |_, &blk| expect(blk.call).to match(/suppress.*abcd1234.flingle.example.com/i) }
+      expect(logger).to receive(:info) { |_, &blk| expect(blk.call).to match(/suppress.*abcd1234.flingle/i) }
 
-      backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+      backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
     end
   end
 end

--- a/spec/matcher_methods.rb
+++ b/spec/matcher_methods.rb
@@ -4,13 +4,13 @@ RSpec::Matchers.define :have_A_record do |relrrname, address|
   match do |actual|
     actual.any? do |rr|
       rr.data.class == Resolv::DNS::Resource::IN::A &&
-        (relrrname.nil? || rr.name == "#{relrrname}.example.com") &&
+        (relrrname.nil? || rr.name == relrrname) &&
         (address.nil? || rr.data.address.to_s == address)
     end
   end
 
   failure_message do |actual|
-    "expected #{actual.pretty_inspect} to have a record '#{relrrname}.example.com A #{address}'"
+    "expected #{actual.pretty_inspect} to have a record '#{relrrname} A #{address}'"
   end
 end
 
@@ -18,13 +18,13 @@ RSpec::Matchers.define :have_AAAA_record do |relrrname, address|
   match do |actual|
     actual.any? do |rr|
       rr.data.class == Resolv::DNS::Resource::IN::AAAA &&
-        (relrrname.nil? || rr.name == "#{relrrname}.example.com") &&
+        (relrrname.nil? || rr.name == relrrname) &&
         (address.nil? || rr.data.address.to_s == address.upcase)
     end
   end
 
   failure_message do |actual|
-    "expected #{actual.pretty_inspect} to have a record '#{relrrname}.example.com AAAA #{address}'"
+    "expected #{actual.pretty_inspect} to have a record '#{relrrname} AAAA #{address}'"
   end
 end
 
@@ -32,13 +32,13 @@ RSpec::Matchers.define :have_PTR_record do |relrrname, dname|
   match do |actual|
     actual.any? do |rr|
       rr.data.class == Resolv::DNS::Resource::IN::PTR &&
-        (relrrname.nil? || rr.name == "#{relrrname}.example.com") &&
+        (relrrname.nil? || rr.name == relrrname) &&
         (dname.nil? || rr.data.name.to_s == dname)
     end
   end
 
   failure_message do |actual|
-    "expected #{actual.pretty_inspect} to have a record '#{relrrname}.example.com PTR #{dname}'"
+    "expected #{actual.pretty_inspect} to have a record '#{relrrname} PTR #{dname}'"
   end
 end
 
@@ -46,13 +46,13 @@ RSpec::Matchers.define :have_TXT_record do |relrrname, strings|
   match do |actual|
     actual.any? do |rr|
       rr.data.class == Resolv::DNS::Resource::IN::TXT &&
-        (relrrname.nil? || rr.name == "#{relrrname}.example.com") &&
+        (relrrname.nil? || rr.name == relrrname) &&
         (strings.nil? || rr.data.strings == strings)
     end
   end
 
   failure_message do |actual|
-    "expected #{actual.pretty_inspect} to have a record '#{relrrname}.example.com TXT #{strings.map { |s| "\"#{s}\"" }.join(" ")}'"
+    "expected #{actual.pretty_inspect} to have a record '#{relrrname} TXT #{strings.map { |s| "\"#{s}\"" }.join(" ")}'"
   end
 end
 
@@ -64,13 +64,13 @@ RSpec::Matchers.define :have_SRV_record do |relrrname, data|
   match do |actual|
     actual.any? do |rr|
       rr.data.class == Resolv::DNS::Resource::IN::SRV &&
-        (relrrname.nil? || rr.name == "#{relrrname}.example.com") &&
+        (relrrname.nil? || rr.name == relrrname) &&
         (data.nil? || srv_data(rr.data) == data)
     end
   end
 
   failure_message do |actual|
-    "expected #{actual.pretty_inspect} to have a record '#{relrrname}.example.com SRV #{data}'"
+    "expected #{actual.pretty_inspect} to have a record '#{relrrname} SRV #{data}'"
   end
 end
 
@@ -78,12 +78,12 @@ RSpec::Matchers.define :have_CNAME_record do |relrrname, dname|
   match do |actual|
     actual.any? do |rr|
       rr.data.class == Resolv::DNS::Resource::IN::CNAME &&
-        (relrrname.nil? || rr.name == "#{relrrname}.example.com") &&
+        (relrrname.nil? || rr.name == relrrname) &&
         (dname.nil? || rr.data.name.to_s == dname)
     end
   end
 
   failure_message do |actual|
-    "expected #{actual.pretty_inspect} to have a record '#{relrrname}.example.com CNAME #{dname}'"
+    "expected #{actual.pretty_inspect} to have a record '#{relrrname} CNAME #{dname}'"
   end
 end

--- a/spec/route53_backend_spec.rb
+++ b/spec/route53_backend_spec.rb
@@ -272,6 +272,24 @@ describe DDNSSD::Backend::Route53 do
         expect(backend.dns_records).to be_empty
       end
     end
+
+    context "receiving records with value having wrong subdomain" do
+      let(:route53_stubs) do
+        {
+          list_resource_record_sets: route53_response_fixture("wrong_subdomain")
+        }
+      end
+
+      it "tolerates it" do
+        allow(logger).to receive(:warn)
+        expect {
+          records = backend.dns_records
+          expect(backend.dns_records).to be_an(Array)
+          expect(backend.dns_records.reject { |rr| DDNSSD::DNSRecord === rr }).to be_empty
+          expect(backend.dns_records.all? { |rr| DDNSSD::DNSRecord === rr }).to be(true)
+        }.to_not raise_error
+      end
+    end
   end
 
   describe "#publish_record" do

--- a/spec/route53_backend_spec.rb
+++ b/spec/route53_backend_spec.rb
@@ -316,7 +316,7 @@ describe DDNSSD::Backend::Route53 do
           .and_call_original
         expect(r53).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :A, "192.0.2.42"))
+        backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :A, "192.0.2.42"))
       end
 
       context "on Throttling error" do
@@ -350,7 +350,7 @@ describe DDNSSD::Backend::Route53 do
           expect(r53).to receive(:change_resource_record_sets).and_call_original.ordered
           expect(Kernel).to_not receive(:sleep)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :A, "192.0.2.42"))
         end
       end
 
@@ -385,7 +385,7 @@ describe DDNSSD::Backend::Route53 do
           expect(r53).to receive(:change_resource_record_sets).and_call_original.ordered
           expect(Kernel).to_not receive(:sleep)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :A, "192.0.2.42"))
         end
       end
     end
@@ -413,7 +413,7 @@ describe DDNSSD::Backend::Route53 do
           .and_call_original
         expect(r53).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+        backend.publish_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
       end
     end
 
@@ -440,7 +440,7 @@ describe DDNSSD::Backend::Route53 do
           .and_call_original
         expect(r53).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("db.example.com", 42, :CNAME, "pgsql.host27.example.com"))
+        backend.publish_record(DDNSSD::DNSRecord.new("db", 42, :CNAME, "pgsql.host27"))
       end
     end
 
@@ -467,7 +467,7 @@ describe DDNSSD::Backend::Route53 do
           .and_call_original
         expect(r53).to_not receive(:list_resource_record_sets)
 
-        backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :TXT, 'something "funny"', "this too"))
+        backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :TXT, 'something "funny"', "this too"))
       end
     end
 
@@ -495,15 +495,15 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
         end
       end
 
       context "with existing records for the name/type" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host3.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host3")
           )
         end
 
@@ -543,16 +543,16 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
         end
       end
 
       context "with the record already existent" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host3.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host3"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22")
           )
         end
 
@@ -593,7 +593,7 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
         end
       end
 
@@ -678,15 +678,15 @@ describe DDNSSD::Backend::Route53 do
               .and_call_original
             expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
           end
         end
 
         context "with records disappearing" do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
-              DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"),
-              DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host3.example.com")
+              DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"),
+              DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host3")
             )
           end
 
@@ -747,7 +747,7 @@ describe DDNSSD::Backend::Route53 do
                    ).and_call_original.ordered
             expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
           end
         end
 
@@ -774,7 +774,7 @@ describe DDNSSD::Backend::Route53 do
               expect(r53).to_not receive(:list_resource_record_sets)
               expect(r53).to_not receive(:change_resource_record_sets)
 
-              backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com"))
+              backend.publish_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22"))
             end
           end
         end
@@ -805,15 +805,15 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
         end
       end
 
       context "with existing records for the name/type" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "xyzzy._http._tcp.example.com"),
-            DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "argle._http._tcp.example.com")
+            DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "xyzzy._http._tcp"),
+            DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "argle._http._tcp")
           )
         end
 
@@ -853,14 +853,14 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
         end
       end
 
       context "including the one we want to add" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com")
+            DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp")
           )
         end
 
@@ -897,7 +897,7 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+          backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
         end
       end
 
@@ -982,15 +982,15 @@ describe DDNSSD::Backend::Route53 do
               .and_call_original
             expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
           end
         end
 
         context "with records disappearing" do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "xyzzy._http._tcp.example.com"),
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "argle._http._tcp.example.com")
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "xyzzy._http._tcp"),
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "argle._http._tcp")
             )
           end
 
@@ -1051,7 +1051,7 @@ describe DDNSSD::Backend::Route53 do
                    ).and_call_original.ordered
             expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com"))
+            backend.publish_record(DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp"))
           end
         end
       end
@@ -1063,7 +1063,7 @@ describe DDNSSD::Backend::Route53 do
       context "with no other records in the set" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42")
           )
         end
 
@@ -1089,16 +1089,16 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
 
       context "with other records in the set" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.1"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.180")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.1"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.180")
           )
         end
 
@@ -1138,15 +1138,15 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
 
       context "with our record already gone" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.1"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.180")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.1"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.180")
           )
         end
 
@@ -1185,14 +1185,14 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
 
       context "when faced with an InvalidChangeBatch error" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42")
           )
         end
 
@@ -1259,7 +1259,7 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
 
         context "that never resolves" do
@@ -1285,7 +1285,7 @@ describe DDNSSD::Backend::Route53 do
               expect(r53).to_not receive(:list_resource_record_sets)
               expect(r53).to_not receive(:change_resource_record_sets)
 
-              backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+              backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
             end
           end
         end
@@ -1314,9 +1314,9 @@ describe DDNSSD::Backend::Route53 do
 
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.1"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.180")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.1"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.180")
           )
         end
 
@@ -1330,7 +1330,7 @@ describe DDNSSD::Backend::Route53 do
           expect(r53).to receive(:change_resource_record_sets).and_call_original.ordered
           expect(Kernel).to_not receive(:sleep)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
 
@@ -1357,9 +1357,9 @@ describe DDNSSD::Backend::Route53 do
 
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.1"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"),
-            DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.180")
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.1"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"),
+            DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.180")
           )
         end
 
@@ -1373,7 +1373,7 @@ describe DDNSSD::Backend::Route53 do
           expect(r53).to receive(:change_resource_record_sets).and_call_original.ordered
           expect(Kernel).to_not receive(:sleep)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle.example.com", 42, :A, "192.0.2.42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.flingle", 42, :A, "192.0.2.42"))
         end
       end
     end
@@ -1382,7 +1382,7 @@ describe DDNSSD::Backend::Route53 do
       context "with no other records in the set" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42")
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42")
           )
         end
 
@@ -1408,16 +1408,16 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
         end
       end
 
       context "with other records in the set" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::1"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::180")
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"),
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::180")
           )
         end
 
@@ -1457,15 +1457,15 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
         end
       end
 
       context "with our record already gone" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::1"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::180")
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::180")
           )
         end
 
@@ -1504,7 +1504,7 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :AAAA, "2001:db8::42"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :AAAA, "2001:db8::42"))
         end
       end
     end
@@ -1513,7 +1513,7 @@ describe DDNSSD::Backend::Route53 do
       context "with no other records in the set" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com")
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42")
           )
         end
 
@@ -1539,16 +1539,16 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"))
         end
       end
 
       context "with other records in the set" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host1.example.com"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host180.example.com")
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"),
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host180")
           )
         end
 
@@ -1588,15 +1588,15 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"))
         end
       end
 
       context "with our record already gone" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host1.example.com"),
-            DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host180.example.com")
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host1"),
+            DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host180")
           )
         end
 
@@ -1635,7 +1635,7 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("flingle.example.com", 42, :CNAME, "host42.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("flingle", 42, :CNAME, "host42"))
         end
       end
     end
@@ -1644,8 +1644,8 @@ describe DDNSSD::Backend::Route53 do
       context "with other SRV records present" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"),
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host2.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"),
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host2")
           )
         end
 
@@ -1683,15 +1683,15 @@ describe DDNSSD::Backend::Route53 do
             .and_call_original
           expect(r53).to_not receive(:list_resource_record_sets)
 
-          backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host2.example.com"))
+          backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host2"))
         end
 
         context "when faced with an InvalidChangeBatch error" do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
-              DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"),
-              DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host3.example.com"),
-              DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host22.example.com")
+              DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"),
+              DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host3"),
+              DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host22")
             )
           end
 
@@ -1786,7 +1786,7 @@ describe DDNSSD::Backend::Route53 do
               .and_call_original
             expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"))
+            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"))
           end
 
           context "that never resolves" do
@@ -1813,7 +1813,7 @@ describe DDNSSD::Backend::Route53 do
                 expect(r53).to_not receive(:list_resource_record_sets)
                 expect(r53).to_not receive(:change_resource_record_sets)
 
-                backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 80, "faff.host1.example.com"))
+                backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 80, "faff.host1"))
               end
             end
           end
@@ -1823,17 +1823,17 @@ describe DDNSSD::Backend::Route53 do
       context "with no other SRV records present" do
         before(:each) do
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1")
           )
           backend.instance_variable_get(:@record_cache).set(
-            DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :TXT, "something funny")
+            DDNSSD::DNSRecord.new("faff._http._tcp", 42, :TXT, "something funny")
           )
         end
 
         context "with no other PTR records" do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com")
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp")
             )
           end
 
@@ -1881,15 +1881,15 @@ describe DDNSSD::Backend::Route53 do
               .and_call_original
             expect(r53).to_not receive(:list_resource_record_sets)
 
-            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"))
+            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"))
           end
         end
 
         context "with other PTR records" do
           before(:each) do
             backend.instance_variable_get(:@record_cache).set(
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "blargh._http._tcp.example.com"),
-              DDNSSD::DNSRecord.new("_http._tcp.example.com", 42, :PTR, "faff._http._tcp.example.com")
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "blargh._http._tcp"),
+              DDNSSD::DNSRecord.new("_http._tcp", 42, :PTR, "faff._http._tcp")
             )
           end
 
@@ -1949,7 +1949,7 @@ describe DDNSSD::Backend::Route53 do
               .and_call_original
             expect(r53).to_not receive(:list_resource_record_sets)
 
-            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"))
+            backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"))
           end
 
           context "when faced with an InvalidChangeBatch error" do
@@ -2099,7 +2099,7 @@ describe DDNSSD::Backend::Route53 do
                 .and_call_original
               expect(r53).to_not receive(:list_resource_record_sets).ordered
 
-              backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp.example.com", 42, :SRV, 0, 0, 8080, "host1.example.com"))
+              backend.suppress_record(DDNSSD::DNSRecord.new("faff._http._tcp", 42, :SRV, 0, 0, 8080, "host1"))
             end
           end
         end
@@ -2108,13 +2108,13 @@ describe DDNSSD::Backend::Route53 do
 
     context "with a TXT record" do
       it "logs an error" do
-        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x.example.com", 60, :TXT, "")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
+        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x", 60, :TXT, "")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
       end
     end
 
     context "with a PTR record" do
       it "logs an error" do
-        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x.example.com", 60, :PTR, "faff.example.com")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
+        expect { backend.suppress_record(DDNSSD::DNSRecord.new("x", 60, :PTR, "faff.example.com")) }.to raise_error(DDNSSD::Backend::InvalidRequest)
       end
     end
 
@@ -2127,12 +2127,12 @@ describe DDNSSD::Backend::Route53 do
     context "receiving any other error" do
       it "logs an error and gives up" do
         backend.instance_variable_get(:@record_cache).set(
-          DDNSSD::DNSRecord.new("abcd1234.faff.example.com", 42, :A, "192.0.2.42")
+          DDNSSD::DNSRecord.new("abcd1234.faff", 42, :A, "192.0.2.42")
         )
         expect(r53).to receive(:change_resource_record_sets).and_raise(RuntimeError)
         expect(logger).to receive(:error)
 
-        backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.faff.example.com", 42, :A, "192.0.2.42"))
+        backend.suppress_record(DDNSSD::DNSRecord.new("abcd1234.faff", 42, :A, "192.0.2.42"))
       end
     end
   end

--- a/spec/service_instance_spec.rb
+++ b/spec/service_instance_spec.rb
@@ -63,7 +63,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "has a SRV record pointing to the container+exposed port" do
-          expect(result).to have_SRV_record("exposed80._http._tcp", "0 0 80 asdfasdfexpo.speccy.example.com")
+          expect(result).to have_SRV_record("exposed80._http._tcp", "0 0 80 asdfasdfexpo.speccy")
         end
 
         it "has an empty TXT record" do
@@ -71,7 +71,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the service instance" do
-          expect(result).to have_PTR_record("_http._tcp", "exposed80._http._tcp.example.com")
+          expect(result).to have_PTR_record("_http._tcp", "exposed80._http._tcp")
         end
       end
 
@@ -87,7 +87,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "has a SRV record pointing to the container+exposed port" do
-          expect(result).to have_SRV_record("exposed80._http._tcp", "0 0 80 asdfasdfexpo.speccy.example.com")
+          expect(result).to have_SRV_record("exposed80._http._tcp", "0 0 80 asdfasdfexpo.speccy")
         end
 
         it "has an empty TXT record" do
@@ -95,7 +95,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the service instance" do
-          expect(result).to have_PTR_record("_http._tcp", "exposed80._http._tcp.example.com")
+          expect(result).to have_PTR_record("_http._tcp", "exposed80._http._tcp")
         end
       end
 
@@ -111,7 +111,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "has a SRV record pointing to the host+published port" do
-          expect(result).to have_SRV_record("pub80._http._tcp", "0 0 8080 speccy.example.com")
+          expect(result).to have_SRV_record("pub80._http._tcp", "0 0 8080 speccy")
         end
 
         it "has an empty TXT record" do
@@ -119,7 +119,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the service instance" do
-          expect(result).to have_PTR_record("_http._tcp", "pub80._http._tcp.example.com")
+          expect(result).to have_PTR_record("_http._tcp", "pub80._http._tcp")
         end
       end
 
@@ -139,7 +139,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "has a SRV record pointing to the host+published port" do
-          expect(result).to have_SRV_record("pub80._http._tcp", "0 0 8080 192-0-2-99.speccy.example.com")
+          expect(result).to have_SRV_record("pub80._http._tcp", "0 0 8080 192-0-2-99.speccy")
         end
 
         it "has an empty TXT record" do
@@ -147,7 +147,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the service instance" do
-          expect(result).to have_PTR_record("_http._tcp", "pub80._http._tcp.example.com")
+          expect(result).to have_PTR_record("_http._tcp", "pub80._http._tcp")
         end
       end
 
@@ -179,7 +179,7 @@ describe DDNSSD::ServiceInstance do
         let(:docker_container) { container_fixture("exposed_port80") }
 
         it "has a SRV record pointing to the container+exposed port" do
-          expect(result).to have_SRV_record("flibbety._http._tcp", "0 0 80 asdfasdfexpo.speccy.example.com")
+          expect(result).to have_SRV_record("flibbety._http._tcp", "0 0 80 asdfasdfexpo.speccy")
         end
 
         it "has an empty TXT record" do
@@ -187,7 +187,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the service instance" do
-          expect(result).to have_PTR_record("_http._tcp", "flibbety._http._tcp.example.com")
+          expect(result).to have_PTR_record("_http._tcp", "flibbety._http._tcp")
         end
       end
 
@@ -195,7 +195,7 @@ describe DDNSSD::ServiceInstance do
         let(:docker_container) { container_fixture("published_port80") }
 
         it "has a SRV record pointing to the host+published port" do
-          expect(result).to have_SRV_record("flibbety._http._tcp", "0 0 8080 speccy.example.com")
+          expect(result).to have_SRV_record("flibbety._http._tcp", "0 0 8080 speccy")
         end
 
         it "has an empty TXT record" do
@@ -203,7 +203,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the service instance" do
-          expect(result).to have_PTR_record("_http._tcp", "flibbety._http._tcp.example.com")
+          expect(result).to have_PTR_record("_http._tcp", "flibbety._http._tcp")
         end
       end
     end
@@ -266,7 +266,7 @@ describe DDNSSD::ServiceInstance do
       end
 
       it "has a _udp SRV record" do
-        expect(result).to have_SRV_record("pub80._http._udp", "0 0 8080 speccy.example.com")
+        expect(result).to have_SRV_record("pub80._http._udp", "0 0 8080 speccy")
       end
 
       it "has an empty _udp TXT record" do
@@ -274,7 +274,7 @@ describe DDNSSD::ServiceInstance do
       end
 
       it "points to the _udp service instance" do
-        expect(result).to have_PTR_record("_http._udp", "pub80._http._udp.example.com")
+        expect(result).to have_PTR_record("_http._udp", "pub80._http._udp")
       end
     end
 
@@ -289,7 +289,7 @@ describe DDNSSD::ServiceInstance do
 
       %w{_tcp _udp}.each do |proto|
         it "has a #{proto} SRV record" do
-          expect(result).to have_SRV_record("pub80._http.#{proto}", "0 0 8080 speccy.example.com")
+          expect(result).to have_SRV_record("pub80._http.#{proto}", "0 0 8080 speccy")
         end
 
         it "has an empty #{proto} TXT record" do
@@ -297,7 +297,7 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "points to the #{proto} service instance" do
-          expect(result).to have_PTR_record("_http.#{proto}", "pub80._http.#{proto}.example.com")
+          expect(result).to have_PTR_record("_http.#{proto}", "pub80._http.#{proto}")
         end
       end
     end
@@ -324,7 +324,7 @@ describe DDNSSD::ServiceInstance do
       end
 
       it "has a customised SRV record" do
-        expect(result).to have_SRV_record("exposed80._http._tcp", "42 0 80 asdfasdfexpo.speccy.example.com")
+        expect(result).to have_SRV_record("exposed80._http._tcp", "42 0 80 asdfasdfexpo.speccy")
       end
     end
 
@@ -362,7 +362,7 @@ describe DDNSSD::ServiceInstance do
       end
 
       it "has a customised SRV record" do
-        expect(result).to have_SRV_record("exposed80._http._tcp", "0 42 80 asdfasdfexpo.speccy.example.com")
+        expect(result).to have_SRV_record("exposed80._http._tcp", "0 42 80 asdfasdfexpo.speccy")
       end
     end
 
@@ -560,8 +560,8 @@ describe DDNSSD::ServiceInstance do
         let(:docker_container) { container_fixture("exposed_port80") }
 
         it "creates CNAME records pointing to the container+exposed port" do
-          expect(result).to have_CNAME_record("some.thing.funny", "asdfasdfexpo.speccy.example.com")
-          expect(result).to have_CNAME_record("pgsql-master", "asdfasdfexpo.speccy.example.com")
+          expect(result).to have_CNAME_record("some.thing.funny", "asdfasdfexpo.speccy")
+          expect(result).to have_CNAME_record("pgsql-master", "asdfasdfexpo.speccy")
         end
       end
 
@@ -569,8 +569,8 @@ describe DDNSSD::ServiceInstance do
         let(:docker_container) { container_fixture("published_port80") }
 
         it "creates CNAME records pointing to the container+exposed port" do
-          expect(result).to have_CNAME_record("some.thing.funny", "speccy.example.com")
-          expect(result).to have_CNAME_record("pgsql-master", "speccy.example.com")
+          expect(result).to have_CNAME_record("some.thing.funny", "speccy")
+          expect(result).to have_CNAME_record("pgsql-master", "speccy")
         end
       end
 
@@ -582,8 +582,8 @@ describe DDNSSD::ServiceInstance do
         end
 
         it "creates CNAME records pointing to the container+exposed port" do
-          expect(result).to have_CNAME_record("some.thing.funny", "192-0-2-99.speccy.example.com")
-          expect(result).to have_CNAME_record("pgsql-master", "192-0-2-99.speccy.example.com")
+          expect(result).to have_CNAME_record("some.thing.funny", "192-0-2-99.speccy")
+          expect(result).to have_CNAME_record("pgsql-master", "192-0-2-99.speccy")
         end
       end
     end

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -104,7 +104,7 @@ describe DDNSSD::System do
       end
 
       it "publishes the host's IP address" do
-        expect(mock_backend).to receive(:publish_record).with(DDNSSD::DNSRecord.new("speccy.example.com", 60, :A, "192.0.2.42"))
+        expect(mock_backend).to receive(:publish_record).with(DDNSSD::DNSRecord.new("speccy", 60, :A, "192.0.2.42"))
 
         system.run
       end
@@ -113,8 +113,8 @@ describe DDNSSD::System do
         let(:env) { base_env.merge("DDNSSD_BACKEND" => "test_queue,log") }
 
         it "publishes the host's IP address to all backends" do
-          expect(mock_backend).to receive(:publish_record).with(DDNSSD::DNSRecord.new("speccy.example.com", 60, :A, "192.0.2.42"))
-          expect(mock_log_backend).to receive(:publish_record).with(DDNSSD::DNSRecord.new("speccy.example.com", 60, :A, "192.0.2.42"))
+          expect(mock_backend).to receive(:publish_record).with(DDNSSD::DNSRecord.new("speccy", 60, :A, "192.0.2.42"))
+          expect(mock_log_backend).to receive(:publish_record).with(DDNSSD::DNSRecord.new("speccy", 60, :A, "192.0.2.42"))
 
           system.run
         end
@@ -421,10 +421,10 @@ describe DDNSSD::System do
 
         expect(mock_backend)
           .to receive(:suppress_record)
-          .with(eq(DDNSSD::DNSRecord.new("pub80._http._tcp.example.com", 60, :SRV, 0, 0, 8080, "speccy.example.com")))
+          .with(eq(DDNSSD::DNSRecord.new("pub80._http._tcp", 60, :SRV, 0, 0, 8080, "speccy")))
         expect(mock_backend)
           .to receive(:publish_record)
-          .with(eq(DDNSSD::DNSRecord.new("pub80._http._tcp.example.com", 60, :SRV, 0, 0, 1337, "speccy.example.com")))
+          .with(eq(DDNSSD::DNSRecord.new("pub80._http._tcp", 60, :SRV, 0, 0, 1337, "speccy")))
 
         system.send(:reconcile_containers, mock_backend)
       end


### PR DESCRIPTION
Backends are responsible for fully-qualifying names. This should complete support for multiple backends with different base domains.